### PR TITLE
Update vision language models to latest 2026 SOTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,12 @@
 
 #### Multimodal Models (Vision + Language)
 
-- **[LLaVA 1.6 / Next (Liu et al.)](https://github.com/haotian-liu/LLaVA)** ![GitHub stars](https://img.shields.io/github/stars/haotian-liu/LLaVA?style=social) - Most popular open vision-language model. Strong image understanding and reasoning.
-- **[Phi-3.5-Vision / Phi-4-Multimodal (Microsoft)](https://github.com/microsoft/PhiCookBook)** ![GitHub stars](https://img.shields.io/github/stars/microsoft/PhiCookBook?style=social) - Lightweight multimodal with excellent chart/table/document understanding.
-- **[Qwen2.5-VL (Alibaba)](https://github.com/QwenLM/Qwen-VL)** ![GitHub stars](https://img.shields.io/github/stars/QwenLM/Qwen-VL?style=social) - State-of-the-art open multimodal (text + image + video). Tops many VL benchmarks.
-- **[InternVL 2.5 (OpenGVLab)](https://github.com/OpenGVLab/InternVL)** ![GitHub stars](https://img.shields.io/github/stars/OpenGVLab/InternVL?style=social) - Massive open multimodal family (up to 26B) with strong performance on OCR, charts, and video.
+- **[Qwen3-VL (Alibaba)](https://github.com/QwenLM/Qwen3-VL)** ![GitHub stars](https://img.shields.io/github/stars/QwenLM/Qwen3-VL?style=social) - Latest flagship VLM with native 256K context (expandable to 1M), visual agent capabilities, 3D grounding, and superior multimodal reasoning. Major leap over Qwen2.5-VL.
+- **[InternVL3 (OpenGVLab)](https://github.com/OpenGVLab/InternVL)** ![GitHub stars](https://img.shields.io/github/stars/OpenGVLab/InternVL?style=social) - Native multimodal pretraining with mixed preference optimization (MPO). Superior perception and reasoning over InternVL 2.5, extends to GUI agents and 3D vision.
+- **[GLM-4.5V / GLM-4.1V-Thinking (Zhipu AI)](https://github.com/zai-org/GLM-V)** ![GitHub stars](https://img.shields.io/github/stars/zai-org/GLM-V?style=social) - Strong multimodal reasoning with scalable reinforcement learning. Compares favorably with Gemini-2.5-Flash on benchmarks.
+- **[LLaVA-OneVision](https://github.com/LLaVA-VL/LLaVA-NeXT)** ![GitHub stars](https://img.shields.io/github/stars/LLaVA-VL/LLaVA-NeXT?style=social) - Successor to LLaVA 1.6 with expanded capabilities across vision-language tasks.
+- **[MiniCPM-V 2.6](https://github.com/OpenBMB/MiniCPM-V)** ![GitHub stars](https://img.shields.io/github/stars/OpenBMB/MiniCPM-V?style=social) - Handles images up to 1.8M pixels with top-tier OCR performance. Excellent for on-device deployment.
+- **[Gemma 3 (Google)](https://github.com/google-deepmind/gemma)** ![GitHub stars](https://img.shields.io/github/stars/google-deepmind/gemma?style=social) - Lightweight multimodal supporting vision-language input, optimized for efficiency and on-device use.
 
 #### Speech & Audio Models (TTS, STT, Music)
 


### PR DESCRIPTION
## Summary

The vision language models section was outdated (listing Qwen2.5-VL, InternVL 2.5, LLaVA 1.6). This PR updates to the current state-of-the-art models as of March 2026.

## Changes

| Before | After |
|--------|-------|
| Qwen2.5-VL | **Qwen3-VL** - Major leap with 256K context, visual agents, 3D grounding |
| InternVL 2.5 | **InternVL3** - Native multimodal pretraining, MPO, GUI agents |
| LLaVA 1.6 / Next | **LLaVA-OneVision** - Successor with expanded capabilities |
| (new) | **GLM-4.5V / GLM-4.1V-Thinking** - Zhipu AI, compares with Gemini-2.5-Flash |
| (new) | **MiniCPM-V 2.6** - 1.8M pixel images, top-tier OCR |
| (new) | **Gemma 3** - Lightweight multimodal from Google |

## Research Sources

- [Qwen3-VL GitHub](https://github.com/QwenLM/Qwen3-VL) - Released Sept-Oct 2025
- [InternVL3 Paper](https://arxiv.org/html/2504.10479v1) - April 2025
- [GLM-V GitHub](https://github.com/zai-org/GLM-V) - Zhipu AI
- [SiliconFlow 2026 VLM Guide](https://www.siliconflow.com/articles/en/best-open-source-multimodal-models-2025)

## Benchmarks

InternVL3-78B achieves 72.2 MMMU (vs InternVL 2.5-78B at 70.0), outperforming GPT-4o on several multimodal benchmarks. Qwen3-VL introduces native 256K context with expandable 1M support.

---

Fixes feedback about outdated VLM listings.