### PR TITLE
Add Forgetful to Agent Memory & State

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@
 
 - **[Letta (ex-MemGPT)](https://github.com/letta-ai/letta)** ![GitHub stars](https://img.shields.io/github/stars/letta-ai/letta?style=social) - Platform for building stateful agents with advanced memory that learn and self-improve over time.
 - **[Mem0](https://github.com/mem0ai/mem0)** ![GitHub stars](https://img.shields.io/github/stars/mem0ai/mem0?style=social) - Universal memory layer for AI agents. Persistent, multi-session memory across models and environments.
+- **[Forgetful](https://github.com/ScottRBK/forgetful)** ![GitHub stars](https://img.shields.io/github/stars/ScottRBK/forgetful?style=social) - MCP server for persistent AI agent memory. Stores atomic single-concept notes and auto-links them into a knowledge graph via semantic similarity. SQLite or PostgreSQL.
 
 ---
 


### PR DESCRIPTION
### What this adds

[Forgetful](https://github.com/ScottRBK/forgetful) in the **Agent Memory & State** section.

It's an MCP server that gives AI agents memory that persists across sessions. Each memory is one concept (Zettelkasten-style), and the system automatically links related memories into a knowledge graph based on vector similarity.

### Why include it

The section currently has Letta (stateful agent platform) and Mem0 (universal memory layer). Forgetful is a different thing: it's an MCP server, so it plugs directly into the protocol without needing a separate platform. It's opinionated about structure (atomic notes, auto-linking, token budget limits) rather than being a general-purpose memory store.

Basics:
- MIT license
- On PyPI as `forgetful-ai`, Docker images on GHCR
- Active commits, CI via GitHub Actions, integration + E2E tests
- Docs for tool reference, API, configuration, self-hosting, search, and setup guides for 7 agent platforms

### What it does

- Semantic search with cross-encoder reranking
- Planning and Skills for cross-agent distribution
- Auto-links memories at configurable similarity thresholds to build a knowledge graph
- Caps token usage per query so it doesn't eat the LLM's context window
- 42 tools behind a meta-tool discovery layer (only 3 base tools exposed to keep things lean)
- Embedding via FastEmbed locally, or OpenAI/Google/Azure
- STDIO and HTTP transports, OAuth2/OIDC auth
- Tested with Claude Code, Claude Desktop, Copilot CLI, Cursor, Codex, Gemini CLI, Opencode

### Checklist

- [x] Not a duplicate
- [x] Placed in best-fit section (Agent Memory & State)
- [x] Short, neutral description
- [x] Links to official repo
- [x] Star badge included
- [x] Links verified
- [x] OSI-approved license (MIT)
- [x] Active maintenance
