### PR TITLE
feat: add Web Data Ingestion sub-section with Crawl4AI and Lightpanda

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,11 @@
 - **[Unstructured](https://github.com/Unstructured-IO/unstructured)** ![GitHub stars](https://img.shields.io/github/stars/Unstructured-IO/unstructured?style=social) - Best-in-class document preprocessing.
 - **[ColPali / ColQwen](https://github.com/illuin-tech/colpali)** ![GitHub stars](https://img.shields.io/github/stars/illuin-tech/colpali?style=social) - Vision-language models for document retrieval.
 
+#### Web Data Ingestion
+
+- **[Crawl4AI](https://github.com/unclecode/crawl4ai)** ![GitHub stars](https://img.shields.io/github/stars/unclecode/crawl4ai?style=social) - LLM-friendly web crawler that turns websites into clean Markdown for RAG and agentic workflows.
+- **[Lightpanda](https://github.com/lightpanda-io/browser)** ![GitHub stars](https://img.shields.io/github/stars/lightpanda-io/browser?style=social) - Machine-first headless browser in Zig; rendering-free and ultra-lightweight for AI agent browsing.
+
 ---
 
 ### 🎨 6. Generative Media Tools


### PR DESCRIPTION
Proposing a new Web Data Ingestion sub-section for Section 5.

While traditional scrapers are built for humans, these tools represent a "machine-first" approach to the web:

[Crawl4AI](https://github.com/unclecode/crawl4ai): The leading choice for converting the web into clean, LLM-ready Markdown/JSON.
[Lightpanda](https://github.com/lightpanda-io/browser): A high-performance browser runtime built in Zig that bypasses rendering for maximum efficiency.

These tools are essential for production-grade RAG and autonomous agents, helping translate complex web data into simple, structured solutions. Both are OSI-licensed and actively maintained.