### PR TITLE
feat: add .moltfounders/ agent rules directory

### DIFF
--- a/.moltfounders/README.md
+++ b/.moltfounders/README.md
@@ -1,0 +1,26 @@
+# .moltfounders/
+
+This directory defines how AI agents maintain this repository.
+
+Agents participating in the [MoltFounders](https://moltfounders.com) workspace for this repo read these files on every run and follow them exactly. Rules are versioned here like code — propose changes via PR, same as everything else.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `labels.md` | Canonical GitHub label definitions |
+| `issue-triage.md` | How to triage and respond to issues |
+| `pr-review.md` | How to review pull requests |
+| `research.md` | How to discover and suggest new entries |
+| `staleness.md` | How to handle stale issues and PRs |
+
+## Principles
+
+- **Agents prepare, humans decide.** Agents review, comment, and label. Only the repo maintainer merges.
+- **Idempotent by default.** Once an agent has handled an item, it won't touch it again unless the label is removed.
+- **Transparent.** Anyone can read exactly how submissions are reviewed by reading this directory.
+- **Community-editable.** Want to change how the repo is maintained? Open a PR against these files.
+
+## Branch Protection Note
+
+Changes to `.moltfounders/` should only be merged by the repo maintainer, as they directly affect agent behavior.

--- a/.moltfounders/issue-triage.md
+++ b/.moltfounders/issue-triage.md
@@ -1,0 +1,71 @@
+# Issue Triage Rules
+
+## When to Run
+
+On every agent loop cycle, scan all open issues.
+
+## Skip Conditions (do not process if any apply)
+
+- Issue already has the `agent:reviewed` label → skip entirely, do not re-comment
+- Issue was opened by an agent (check author against known agent names) → skip
+- Issue is a GitHub-generated issue (dependabot, etc.) → skip
+
+## Triage Steps
+
+For each issue not skipped:
+
+### 1. Classify the issue type
+
+- **Addition request** — someone wants a new project added
+- **Removal request** — someone wants an existing entry removed (outdated, no longer open-source, etc.)
+- **Correction** — fixing a description, link, or category placement
+- **Question / discussion** — not a concrete change request
+- **Spam / off-topic** — unrelated to the repo purpose
+
+### 2. Evaluate based on type
+
+**Addition requests:**
+- Does the suggested project have an OSI-approved license?
+- Is it genuinely open-source (full weights/code publicly available, not "open" marketing)?
+- Last commit within 6 months? (Check GitHub API)
+- Does it fit an existing category in the README?
+- Is it already in the list? (Search README for project name and GitHub URL)
+- Does it have real adoption (stars, downloads, community)? Use judgment — a genuinely novel tool with fewer stars is ok.
+
+**Removal requests:**
+- Is the reason valid? (project dead, license changed, moved closed-source)
+- Verify the claim independently if possible.
+
+**Corrections:**
+- Is the correction factually accurate?
+- Does it follow the existing format?
+
+**Questions/discussions:**
+- Acknowledge, answer if you can, label `needs-human` if it requires maintainer judgment.
+
+**Spam/off-topic:**
+- Label `needs-human`, leave a polite comment explaining the repo's scope.
+
+### 3. Comment
+
+Leave a clear, helpful comment:
+- What you found
+- Your verdict (looks good / issues found / needs more info)
+- Specific actionable feedback if changes are needed
+- If the submission looks solid, say so clearly and that it's ready for a PR
+
+Be friendly and constructive. Contributors put effort in — acknowledge that.
+
+### 4. Apply labels
+
+- Always apply `agent:reviewed` after handling
+- Apply `agent:commented` if you left a comment
+- Apply `duplicate`, `not-open-source`, `not-actively-maintained`, or `needs-info` as appropriate
+- Apply `needs-human` if you cannot resolve it confidently
+
+## Edge Cases
+
+- **Ambiguous license:** Label `needs-human`, comment asking for clarification
+- **Project is popular but license is unclear:** Same as above — do not approve without confirmed OSI license
+- **Issue is very old (>90 days, no activity):** Follow staleness rules in `staleness.md`
+- **Submitter is aggressive or rude:** Stay professional, label `needs-human`, do not engage further

--- a/.moltfounders/labels.md
+++ b/.moltfounders/labels.md
@@ -1,0 +1,29 @@
+# Labels
+
+Canonical GitHub labels used by agents in this repository.
+
+## Agent Labels
+
+| Label | Color | Description |
+|-------|-------|-------------|
+| `agent:reviewed` | `#0075ca` | Item was reviewed by an agent — will not be re-reviewed automatically |
+| `agent:commented` | `#cfd3d7` | Agent left a comment on this item |
+| `agent:approved` | `#0e8a16` | Agent approved this PR (still needs maintainer merge) |
+| `agent:changes-requested` | `#e4e669` | Agent requested changes on this PR |
+| `agent:suggested` | `#d4edda` | Agent suggested this entry via research loop |
+
+## Status Labels
+
+| Label | Color | Description |
+|-------|-------|-------------|
+| `needs-human` | `#e11d48` | Needs maintainer attention — agent could not resolve |
+| `stale` | `#ededed` | No activity for an extended period |
+| `duplicate` | `#cfd3d7` | Already exists in the list |
+| `not-open-source` | `#b60205` | Project does not meet open-source criteria |
+| `not-actively-maintained` | `#e4e669` | Last commit >6 months ago or project abandoned |
+| `needs-info` | `#fbca04` | Waiting on submitter for more information |
+
+## Setup
+
+Agents should ensure all labels above exist in the repo before executing loops.
+If a label is missing, create it with the specified color and description via the GitHub API before proceeding.

--- a/.moltfounders/pr-review.md
+++ b/.moltfounders/pr-review.md
@@ -1,0 +1,93 @@
+# PR Review Rules
+
+## When to Run
+
+On every agent loop cycle, scan all open pull requests.
+
+## Skip Conditions (do not process if any apply)
+
+- PR already has `agent:reviewed` label → skip entirely
+- PR is a draft → skip (wait until it's marked ready)
+- PR was opened by an agent → skip (avoid self-review loops)
+- PR is from a bot (dependabot, renovate, etc.) → label `needs-human`, skip
+
+## Review Steps
+
+For each PR not skipped:
+
+### 1. Understand what the PR does
+
+- Read the PR title and description
+- Read the diff carefully — what entries are being added, removed, or changed?
+
+### 2. Structural checks
+
+- Does the PR follow the format in `CONTRIBUTING.md`?
+- Is the entry placed in the correct section and category?
+- Does it use the correct badge format (GitHub stars badge, etc.)?
+- Is the link valid? (Check the URL resolves to the right repo)
+- Is the description concise and factual (not marketing language)?
+- Does it include the project name in bold + link format?
+
+### 3. Content checks (for additions)
+
+**Open source verification:**
+- Is the license OSI-approved? Check the repo's LICENSE file directly.
+- Is the full code/model publicly available, or is it "open-ish" (API-only, partial weights)? If the latter → request changes, explain the standard.
+
+**Activity check:**
+- When was the last commit? If >6 months → request changes with `not-actively-maintained` label
+- Are there recent releases or activity? Stars alone are not enough.
+
+**Duplicate check:**
+- Search the current README (not just the PR diff) for the project name and GitHub URL
+- If duplicate → comment clearly, apply `duplicate` label, request closure
+
+**Category fit:**
+- Does it belong in the section it was placed in?
+- If it could fit better elsewhere, suggest the right section
+
+**Quality bar:**
+- Is this project genuinely notable? Real adoption, useful to the community?
+- Avoid listing every possible project — the list should stay curated and high-signal
+
+### 4. For removals
+
+- Is the reason stated? If not, ask.
+- Verify the claim: is the project actually dead/closed-source/abandoned?
+- If valid → approve with a note confirming your verification
+
+### 5. For corrections
+
+- Is the correction accurate?
+- Does it maintain correct formatting?
+
+### 6. Leave your review comment
+
+Be specific:
+- List each issue found with a clear explanation
+- If approving: say exactly why it meets the bar
+- If requesting changes: give actionable, friendly guidance
+
+**Do not:** leave vague comments like "looks good" or "needs work" without detail.
+
+### 7. Apply labels and set review status
+
+- Always apply `agent:reviewed`
+- Apply `agent:approved` if the PR meets all criteria
+- Apply `agent:changes-requested` if changes are needed
+- Apply relevant issue labels (`duplicate`, `not-open-source`, etc.) as needed
+- Apply `needs-human` for anything that requires maintainer judgment (borderline cases, disputes, etc.)
+
+## Important: Agent approval ≠ merge
+
+An `agent:approved` label means the PR passed automated review. **Only the maintainer merges.** The agent never merges PRs directly.
+
+## Edge Cases
+
+- **PR has merge conflicts:** Comment asking the author to rebase. Do not approve until resolved.
+- **PR fixes a broken link only:** Fast-track approve, these are unambiguously good.
+- **Author disagrees with feedback:** Acknowledge their perspective, stand firm on objective criteria (license, activity), label `needs-human` for subjective disputes.
+- **PR has been open >30 days with no author response:** Follow staleness rules in `staleness.md`.
+- **PR adds a commercial product with an "open-source" tier:** Reject unless the core product is fully open-source. Freemium ≠ open-source.
+- **PR adds something already on a sister list (e.g. awesome-llm):** Not a disqualifier — if it fits this list's scope and quality bar, it's fine.

--- a/.moltfounders/research.md
+++ b/.moltfounders/research.md
@@ -1,0 +1,56 @@
+# Research Loop Rules
+
+## Purpose
+
+Periodically discover new open-source AI projects worth adding to the list and open issues suggesting them.
+
+## Frequency
+
+Run the research loop less frequently than triage/PR review — roughly once per week is sufficient. Do not run if you already opened a research issue in the last 7 days.
+
+## Sources to Check
+
+In order of priority:
+
+1. **GitHub Trending** — `https://github.com/trending` filtered to relevant languages (Python, Rust, C++, TypeScript) and timeframe (weekly)
+2. **Hugging Face Papers** — `https://huggingface.co/papers` for models with released weights
+3. **Papers with Code** — new SOTA results with open implementations
+4. **r/LocalLLaMA** — top posts of the week for community-discovered tools
+5. **Hacker News** — search for "open source AI", "open weights", "self-hosted" in recent Show HN posts
+
+## Qualification Criteria
+
+A project is worth suggesting if it meets **all** of the following:
+
+- OSI-approved license (or clearly open-weights with permissive use)
+- Last commit within 3 months
+- Genuine adoption signal: >200 GitHub stars, OR featured on HN/Reddit front page, OR cited in a notable paper
+- Not already in the list (search README before suggesting)
+- Fits an existing category in the README
+
+## How to Suggest
+
+Open a GitHub issue with:
+- **Title:** `[Research] Add: <Project Name>`
+- **Body:**
+  - Project name + GitHub URL
+  - One-sentence description
+  - License
+  - Stars + last commit date
+  - Suggested category
+  - Why it belongs (what makes it notable)
+  - Source where you found it
+
+Apply label `agent:suggested` to the issue.
+
+## Limits
+
+- Open at most **3 research issues per cycle** — avoid flooding the issue tracker
+- If you find more than 3 good candidates, pick the most notable ones
+- Do not suggest projects you've already suggested (check existing issues with `agent:suggested` label first)
+
+## Edge Cases
+
+- **Project is brand new (<1 week old) but clearly notable:** Still suggest it, note recency explicitly
+- **Project is from a major lab (Meta, Google, Microsoft) with open weights:** Strong signal, suggest it
+- **Project overlaps heavily with an existing entry:** Note the overlap in the issue, let the maintainer decide

--- a/.moltfounders/staleness.md
+++ b/.moltfounders/staleness.md
@@ -1,0 +1,45 @@
+# Staleness Rules
+
+## Purpose
+
+Keep the issue tracker and PR queue clean by handling items that have gone quiet.
+
+## Issues
+
+### Waiting on submitter (`needs-info` label)
+
+- If no response after **14 days**: post a friendly reminder comment
+- If no response after **30 days**: apply `stale` label, comment that it will be closed in 7 days if no response
+- If no response after **37 days**: close the issue with a polite closing comment. Can be reopened if they return.
+
+### General open issues (no special label)
+
+- If open >90 days with no activity and no `agent:reviewed`: triage it now
+- If open >90 days with `agent:reviewed` and no further activity: apply `stale`, comment asking if still relevant
+- If stale for another 14 days after that: label `needs-human` — don't close blindly, let maintainer decide
+
+## Pull Requests
+
+### PRs awaiting author action (`agent:changes-requested`)
+
+- If no response after **14 days**: post a friendly reminder with a summary of what's needed
+- If no response after **30 days**: apply `stale` label, comment that it will be closed in 7 days unless updated
+- If no response after **37 days**: close with a note that they're welcome to reopen once updated
+
+### PRs with merge conflicts
+
+- Comment immediately when detected asking for rebase
+- If not resolved after **14 days**: apply `stale`
+- If not resolved after **30 days**: close with explanation
+
+### PRs that are just waiting (no issues found, `agent:approved`)
+
+- Do not apply stale to these — they're the maintainer's queue, not the agent's
+- Apply `needs-human` if they've been approved >30 days with no merge or comment from maintainer
+
+## General Principles
+
+- Always be friendly and assume good intent — people get busy
+- Never close without a clear comment explaining why and how to reopen
+- When in doubt, label `needs-human` rather than closing unilaterally
+- Do not mark something stale if there was any activity (comment, label, commit) in the window


### PR DESCRIPTION
## What this adds

A `.moltfounders/` directory that defines how AI agents maintain this repo.

### Files
- `README.md` — explains the directory and principles
- `labels.md` — canonical GitHub label definitions
- `issue-triage.md` — triage rules, skip conditions, edge cases
- `pr-review.md` — review criteria, duplicate/license/activity checks
- `research.md` — periodic discovery loop for new projects to suggest
- `staleness.md` — handling quiet issues and PRs

### How it works
Agent loops (running on MoltFounders) fetch these files on every run and follow them exactly. Rules evolve through PRs like any other code — full audit trail, community-editable.

### Principles
- Agents review, comment, and label. Only the maintainer merges.
- Idempotent: once reviewed, items are labeled and won't be re-processed.
- Transparent: anyone can see exactly how submissions are evaluated.