### PR TITLE
Feat: add llama.vim, CodeCompanion.nvim, and AutoTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@
 - **[Time Series Library (TSLib)](https://github.com/thuml/Time-Series-Library)** ![GitHub stars](https://img.shields.io/github/stars/thuml/Time-Series-Library?style=social) - Comprehensive benchmark for time-series models.
 - **[Chronos (Amazon)](https://github.com/amazon-science/chronos-forecasting)** ![GitHub stars](https://img.shields.io/github/stars/amazon-science/chronos-forecasting?style=social) - Pretrained foundation models for time-series forecasting.
 - **[Darts](https://github.com/unit8co/darts)** ![GitHub stars](https://img.shields.io/github/stars/unit8co/darts?style=social) - Easy-to-use time-series forecasting library.
+- **[AutoTS](https://github.com/winedarksea/AutoTS)** ![GitHub stars](https://img.shields.io/github/stars/winedarksea/AutoTS?style=social) - Automated time series forecasting with broad model selection, ensembling, anomaly detection, and holiday effects. Designed for production deployment with minimal setup.
 
 #### Edge / On-device AI
 
@@ -521,6 +522,8 @@
 
 #### IDE Plugins & Extensions
 
+- **[llama.vim](https://github.com/ggml-org/llama.vim)** ![GitHub stars](https://img.shields.io/github/stars/ggml-org/llama.vim?style=social) - Local LLM-powered code completion plugin for Vim/Neovim using llama.cpp. Fast, privacy-first, no API key needed.
+- **[CodeCompanion.nvim](https://github.com/olimorris/codecompanion.nvim)** ![GitHub stars](https://img.shields.io/github/stars/olimorris/codecompanion.nvim?style=social) - AI-powered coding assistant for Neovim. Inline code generation, chat, actions, and tool use with support for multiple LLM providers.
 - **[Continue VS Code / JetBrains](https://github.com/continuedev/continue)** ![GitHub stars](https://img.shields.io/github/stars/continuedev/continue?style=social) - Most installed open-source AI extension.
 - **[Jupyter AI](https://github.com/jupyterlab/jupyter-ai)** ![GitHub stars](https://img.shields.io/github/stars/jupyterlab/jupyter-ai?style=social) - Chat and code generation inside notebooks.
 


### PR DESCRIPTION
## What this adds

Three tools that qualify by license, activity, and adoption — surfaced from issues #2 and #16.

### llama.vim (Section 13 - IDE Plugins)
- **Repo:** https://github.com/ggml-org/llama.vim
- **License:** MIT ✅ | **Stars:** 1,928 ✅ | **Active:** Jan 2026 ✅
- Local LLM code completion for Vim/Neovim via llama.cpp — privacy-first, no API key

### CodeCompanion.nvim (Section 13 - IDE Plugins)
- **Repo:** https://github.com/olimorris/codecompanion.nvim
- **License:** Apache-2.0 ✅ | **Stars:** 6,363 ✅ | **Active:** March 2026 ✅
- Full-featured Neovim AI assistant with chat, inline generation, and multi-provider support

### AutoTS (Section 11 - Time Series)
- **Repo:** https://github.com/winedarksea/AutoTS
- **License:** MIT ✅ | **Stars:** 1,384 ✅ | **Active:** March 2026 ✅
- Automated time series forecasting with model selection, ensembling, and anomaly detection

Closes #16. Partial response to #2 (vim/nvim plugins).