### PR TITLE
Add Rewind for AI Chats to User Interfaces & Self-hosted Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@
 
 #### Local AI Chat UIs & Personal Assistants
 
+* **[Rewind for AI Chats](https://github.com/PME26Elvis/rewind-for-ai-chats)** - ![GitHub stars](https://img.shields.io/github/stars/PME26Elvis/rewind-for-ai-chats) Local-first archive and recap app for revisiting AI conversations across ChatGPT, Grok, Gemini, and Claude.
 - **[OpenClaw](https://github.com/openclaw/openclaw)** ![GitHub stars](https://img.shields.io/github/stars/openclaw/openclaw?style=social) - Local-first personal AI assistant with multi-channel integrations and full agentic task execution.
 - **[Open WebUI](https://github.com/open-webui/open-webui)** ![GitHub stars](https://img.shields.io/github/stars/open-webui/open-webui?style=social) - Most popular self-hosted ChatGPT-style interface.
 - **[text-generation-webui](https://github.com/oobabooga/text-generation-webui)** ![GitHub stars](https://img.shields.io/github/stars/oobabooga/text-generation-webui?style=social) - Web UI for running local LLMs with multiple backends, extensions, and model formats.


### PR DESCRIPTION
This PR adds Rewind for AI Chats to the User Interfaces & Self-hosted Platforms section.

Why it fits:
- Open-source and actively maintained AI tool
- Local-first workflow with browser-local storage and optional local SQLite sync
- Supports importing conversations from ChatGPT, Grok, Gemini, and Claude
- Includes timeline browsing, analytics, and yearly recap
- Has clear documentation and a live demo

Already accepted in awesome-ChatGPT-repositories, which may also help confirm category fit.