### PR TITLE
Add Hashgraph Online to Domain-Specific Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@
 - **[Dify](https://github.com/langgenius/dify)** ![GitHub stars](https://img.shields.io/github/stars/langgenius/dify?style=social) - Production-ready agentic workflow platform.
 - **[OWL (camel-ai/owl)](https://github.com/camel-ai/owl)** ![GitHub stars](https://img.shields.io/github/stars/camel-ai/owl?style=social) - Advanced multi-agent collaboration system.
 - **[SuperAGI](https://github.com/TransformerOptimus/SuperAGI)** ![GitHub stars](https://img.shields.io/github/stars/TransformerOptimus/SuperAGI?style=social) - Dev-first autonomous AI agent platform.
-- **[Hashgraph Online](https://hol.org)** ![GitHub stars](https://img.shields.io/github/stars/hashgraph-online/standards-sdk?style=social) - Trust engine for the agentic internet. Provides verifiable agent identity (Universal Agent IDs), trustless P2P communication (HCS-10), and a registry of 187K+ verified AI agents. Open-source SDKs in TypeScript, Go, and Python.
+- **[Hashgraph Online](https://github.com/hashgraph-online/standards-sdk)** ![GitHub stars](https://img.shields.io/github/stars/hashgraph-online/standards-sdk?style=social) - Trust engine for the agentic internet. Provides verifiable agent identity (Universal Agent IDs), trustless P2P communication (HCS-10), and a registry of 187K+ verified AI agents. Open-source SDKs in TypeScript, Go, and Python.
 
 #### Agent Memory & State
 


### PR DESCRIPTION
## Hashgraph Online (HOL) - Trust Engine for the Agentic Internet

Adding [Hashgraph Online](https://hol.org) to the **Domain-Specific Agents** subsection.

**Why it fits:** HOL is a domain-specific platform for AI agent identity, trust, and communication:

- **Universal Agent ID (UAID)**: Global agent identifiers with self-describing routing and structured skills encoding (HCS-14)
- **HCS-10**: Trustless P2P agent communication protocol
- **Registry**: 187K+ verified agents, 33M+ daily HCS operations on Hedera
- **Server-blind E2E encryption**: ECDH + AES-GCM for private agent messaging
- **Open source**: TypeScript, Go, and Python SDKs — [github.com/hashgraph-online](https://github.com/hashgraph-online)

HOL sits alongside entries like Dify and SuperAGI as agent infrastructure, with a unique focus on decentralized identity, trust verification, and cross-protocol agent communication.