### PR TITLE
Add Kagan to IDE Plugins & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,7 @@
 - **[llama.vim](https://github.com/ggml-org/llama.vim)** ![GitHub stars](https://img.shields.io/github/stars/ggml-org/llama.vim?style=social) - Local LLM-powered code completion plugin for Vim/Neovim using llama.cpp. Fast, privacy-first, no API key needed.
 - **[CodeCompanion.nvim](https://github.com/olimorris/codecompanion.nvim)** ![GitHub stars](https://img.shields.io/github/stars/olimorris/codecompanion.nvim?style=social) - AI-powered coding assistant for Neovim. Inline code generation, chat, actions, and tool use with support for multiple LLM providers.
 - **[Continue VS Code / JetBrains](https://github.com/continuedev/continue)** ![GitHub stars](https://img.shields.io/github/stars/continuedev/continue?style=social) - Most installed open-source AI extension.
+- **[Kagan](https://github.com/kagan-sh/kagan)** ![GitHub stars](https://img.shields.io/github/stars/kagan-sh/kagan?style=social) - Open-source coding agent orchestrator with a VS Code extension for planning, execution, review, and merge workflows.
 - **[Jupyter AI](https://github.com/jupyterlab/jupyter-ai)** ![GitHub stars](https://img.shields.io/github/stars/jupyterlab/jupyter-ai?style=social) - Chat and code generation inside notebooks.
 
 #### Testing & Debugging Tools


### PR DESCRIPTION
## Summary

Adds [Kagan](https://github.com/kagan-sh/kagan) to the **IDE Plugins & Extensions** section.

Kagan is an open-source (MIT) coding agent orchestrator with a newly released VS Code extension. It gives developers a task board, agent chat/status access, live task output, review diffs, and merge workflows directly in the editor while staying connected to the main Kagan CLI/MCP stack.

Basics:
- **Repo:** https://github.com/kagan-sh/kagan
- **License:** MIT
- **VS Marketplace:** https://marketplace.visualstudio.com/items?itemName=kagan.kagan-vscode
- **Open VSX:** https://open-vsx.org/extension/kagan/kagan-vscode
- **Docs:** https://docs.kagan.sh/guides/vscode-extension/
- **Active:** 2026 releases and active maintenance on main

### Checklist

- [x] Not a duplicate
- [x] Placed in best-fit section (IDE Plugins & Extensions)
- [x] Short, neutral description
- [x] Links to official repo
- [x] Star badge included
- [x] Links verified
- [x] OSI-approved license (MIT)
- [x] Active maintenance