### PR TITLE
Add Antigravity Link — mobile MCP bridge for Antigravity IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@
 - **[CodeCompanion.nvim](https://github.com/olimorris/codecompanion.nvim)** ![GitHub stars](https://img.shields.io/github/stars/olimorris/codecompanion.nvim?style=social) - AI-powered coding assistant for Neovim. Inline code generation, chat, actions, and tool use with support for multiple LLM providers.
 - **[Continue VS Code / JetBrains](https://github.com/continuedev/continue)** ![GitHub stars](https://img.shields.io/github/stars/continuedev/continue?style=social) - Most installed open-source AI extension.
 - **[Jupyter AI](https://github.com/jupyterlab/jupyter-ai)** ![GitHub stars](https://img.shields.io/github/stars/jupyterlab/jupyter-ai?style=social) - Chat and code generation inside notebooks.
+- **[Antigravity Link](https://github.com/cafeTechne/antigravity-link-extension)** ![GitHub stars](https://img.shields.io/github/stars/cafeTechne/antigravity-link-extension?style=social) - VS Code extension that bridges mobile devices to Google's Antigravity IDE. Mirror active AI chat sessions on your phone, send messages, upload files, stop AI generation, and automate workflows via 9 MCP tools or a local OpenAPI HTTP API. Listed in the official MCP Registry.
 
 #### Testing & Debugging Tools
 


### PR DESCRIPTION
Adds Antigravity Link to the IDE Plugins & Extensions subsection.