### PR TITLE
docs: add dograh to domain-specific agents in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@
 - **[OWL (camel-ai/owl)](https://github.com/camel-ai/owl)** ![GitHub stars](https://img.shields.io/github/stars/camel-ai/owl?style=social) - Advanced multi-agent collaboration system.
 - **[SuperAGI](https://github.com/TransformerOptimus/SuperAGI)** ![GitHub stars](https://img.shields.io/github/stars/TransformerOptimus/SuperAGI?style=social) - Dev-first autonomous AI agent platform.
 - **[AI-Scientist-v2 (SakanaAI)](https://github.com/SakanaAI/AI-Scientist-v2)** ![GitHub stars](https://img.shields.io/github/stars/SakanaAI/AI-Scientist-v2?style=social) - Workshop-level automated scientific discovery via agentic tree search. Generates novel research ideas, runs experiments, and writes papers.
+- **[Dograh](https://github.com/dograh-hq/dograh)** ![GitHub stars](https://img.shields.io/github/stars/dograh-hq/dograh) - Voice AI platform for building conversational agents with telephony, outbound campaigns, and real-time           
+  STT/LLM/TTS orchestration.
 
 #### Agent Memory & State
 


### PR DESCRIPTION
Hello, thank you for maintaining this awesome list!

[Dograh](https://dograh.com/) is an open-source voice AI platform built with FastAPI. It lets you build conversational AI agents that handle real phone calls — inbound and outbound — with STT, LLM, and TTS orchestration.

- We have been actively developing and maintaining Dograh since 2024 with consistent updates however we went open source in 2025 and have [26 releases](https://github.com/dograh-hq/dograh/releases) so far.
- Dograh solves a real problem — most voice AI platforms are closed-source and expensive. Dograh is fully self-hostable
- Built on top of Pipecat
- There are some genuinely useful features out of the box — pre-recorded audio for lower latency and reduced TTS costs, bulk outbound campaigns with scheduling and retry logic, and blind call transfers to hand off to a human agent mid-conversation
- We maintain an active [Slack community](https://join.slack.com/t/dograh-community/shared_invite/zt-3czr47sw5-MSg1J0kJ7IMPOCHF~03auQ) where a lot of developers and voice agent builders collaborate and engage in productive discussion.
- We are a very small team have had a lot of support from the open source community and strive to give back. We are working hard to make the project meaningful with participation and active discussion with voice agent builders - both developers and non developers

Thanks for your consideration