### PR TITLE
[Research] Add 2 entries to Core Frameworks & Libraries — April 3, 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,13 @@
 - **[TensorFlow](https://github.com/tensorflow/tensorflow)** ![GitHub stars](https://img.shields.io/github/stars/tensorflow/tensorflow?style=social) - End-to-end platform with excellent production deployment, TPU support, and large-scale serving tools.
 - **[JAX](https://github.com/jax-ml/jax)** ![GitHub stars](https://img.shields.io/github/stars/jax-ml/jax?style=social) + **[Flax](https://github.com/google/flax)** ![GitHub stars](https://img.shields.io/github/stars/google/flax?style=social) - High-performance numerical computing with composable transformations (JIT, vmap, grad). Rising favorite for research and scientific ML.
 - **[Keras](https://github.com/keras-team/keras)** ![GitHub stars](https://img.shields.io/github/stars/keras-team/keras?style=social) - High-level, beginner-friendly API that now runs on multiple backends (TensorFlow, JAX, PyTorch). Perfect for rapid experimentation.
+- **[PyTorch Geometric](https://github.com/pyg-team/pytorch_geometric)** ![GitHub stars](https://img.shields.io/github/stars/pyg-team/pytorch_geometric?style=social) - Library for deep learning on irregular input data such as graphs, point clouds, and manifolds. Part of the PyTorch ecosystem.
 
 #### Rust ML Frameworks
 
 - **[Burn](https://github.com/tracel-ai/burn)** ![GitHub stars](https://img.shields.io/github/stars/tracel-ai/burn?style=social) - Next-generation deep learning framework in Rust. Backend-agnostic with CPU, GPU, WebAssembly support.
 - **[Candle (Hugging Face)](https://github.com/huggingface/candle)** ![GitHub stars](https://img.shields.io/github/stars/huggingface/candle?style=social) - Minimalist ML framework for Rust. PyTorch-like API with focus on performance and simplicity.
+- **[linfa](https://github.com/rust-ml/linfa)** ![GitHub stars](https://img.shields.io/github/stars/rust-ml/linfa?style=social) - Comprehensive Rust ML toolkit with classical algorithms. scikit-learn equivalent for Rust with clustering, regression, and preprocessing.
 
 #### NLP & Transformers
 


### PR DESCRIPTION
## Category: Core Frameworks & Libraries (§1)

Adding 2 qualifying projects discovered through targeted research for Day 1 of the 14-day category rotation.

| Project | Stars | License | Why It Fits |
|---------|-------|---------|-------------|
| [linfa](https://github.com/rust-ml/linfa) | 4.5k+ | Apache-2.0 | scikit-learn equivalent for Rust; comprehensive classical ML toolkit |
| [PyTorch Geometric](https://github.com/pyg-team/pytorch_geometric) | 23.5k+ | MIT | PyTorch ecosystem library for GNNs and geometric deep learning |

### Research Sources
- Source 1: Rust ML ecosystem search (arewelearningyet.com, rust-ml organization)
- Source 2: PyTorch ecosystem documentation (pytorch.org/ecosystem)
- Source 3: GitHub trending and search for "rust machine learning framework"

### Verification
All projects checked for:
- [x] OSI-approved license (Apache-2.0, MIT)
- [x] Active development (commits within 3 months)
- [x] >500 stars or notable backing
- [x] Not already in README
- [x] Fits Core Frameworks & Libraries section

### Placement
- **linfa**: Added to "Rust ML Frameworks" subsection alongside Burn and Candle
- **PyTorch Geometric**: Added to "Deep Learning Frameworks" subsection as part of PyTorch ecosystem