### PR TITLE
Add code-tour — AI CodeTour walkthrough generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@
 - **[CodeCompanion.nvim](https://github.com/olimorris/codecompanion.nvim)** ![GitHub stars](https://img.shields.io/github/stars/olimorris/codecompanion.nvim?style=social) - AI-powered coding assistant for Neovim. Inline code generation, chat, actions, and tool use with support for multiple LLM providers.
 - **[Continue VS Code / JetBrains](https://github.com/continuedev/continue)** ![GitHub stars](https://img.shields.io/github/stars/continuedev/continue?style=social) - Most installed open-source AI extension.
 - **[Jupyter AI](https://github.com/jupyterlab/jupyter-ai)** ![GitHub stars](https://img.shields.io/github/stars/jupyterlab/jupyter-ai?style=social) - Chat and code generation inside notebooks.
+- **[Code Tour](https://github.com/vaddisrinivas/code-tour)** ![GitHub stars](https://img.shields.io/github/stars/vaddisrinivas/code-tour?style=social) - AI-powered CodeTour walkthrough generator. Creates persona-targeted, step-by-step `.tour` files linking to real files and line numbers for VS Code.
 
 #### UI Components & Chat Libraries
 


### PR DESCRIPTION
## Summary

- Adds [code-tour](https://github.com/vaddisrinivas/code-tour) to the **IDE Plugins & Extensions** section under Developer Tools & Integrations
- MIT-licensed, open-source AI tool that generates CodeTour `.tour` files for VS Code
- Creates persona-targeted, step-by-step walkthroughs linked to real files and line numbers

## Checklist

- [x] Truly open source (MIT license)
- [x] Actively maintained
- [x] Relevant to the open-source AI ecosystem
- [x] No trailing parenthetical metadata notes
- [x] GitHub star badge included
- [x] No duplicates in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)