### PR TITLE
[Research] Add 2 entries to Open Foundation Models — 2026-04-04 (Period 155)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@
 - **[Phi-4 (Microsoft)](https://github.com/microsoft/PhiCookBook)** ![GitHub stars](https://img.shields.io/github/stars/microsoft/PhiCookBook?style=social) - Small but highly capable models optimized for reasoning, edge devices, and on-device inference. Includes Phi-4-reasoning variants with thinking capabilities.
 - **[GLM-5 (Zhipu AI)](https://github.com/zai-org/GLM-5)** ![GitHub stars](https://img.shields.io/github/stars/zai-org/GLM-5?style=social) - Strong open model line with solid coding, reasoning, and agentic-task performance.
 - **[OLMo 2 (Allen AI)](https://github.com/allenai/OLMo)** ![GitHub stars](https://img.shields.io/github/stars/allenai/OLMo?style=social) - Fully open-source LLMs (1B–32B) with complete transparency: models, data, training code, and logs. Designed by scientists, for scientists.
+- **[Llama 4 (Meta)](https://github.com/meta-llama/llama-models)** ![GitHub stars](https://img.shields.io/github/stars/meta-llama/llama-models?style=social) - First native multimodal MoE release with Scout (17B/16E) and Maverick (17B/128E) variants. Open weights with native vision-language capabilities and 10+ language support.
+- **[Step-3.5-Flash (StepFun)](https://github.com/stepfun-ai/Step-3.5-Flash)** ![GitHub stars](https://img.shields.io/github/stars/stepfun-ai/Step-3.5-Flash?style=social) - 196B MoE open-source foundation model (11B active) with 256K context, frontier reasoning, and agentic capabilities. Apache 2.0 licensed.
 
 #### Coding & Reasoning Models
 


### PR DESCRIPTION
## Category: Open Foundation Models

Adding 2 qualifying open-weight foundation models discovered through targeted research for period 155.

| Project | Stars | License | Why It Fits |
|---------|-------|---------|-------------|
| Llama 4 | 7544 | Llama 4 License | Native multimodal MoE from Meta - Scout (17B/16E) and Maverick (17B/128E) variants with vision-language capabilities |
| Step-3.5-Flash | 1975 | Apache 2.0 | 196B MoE (11B active) with 256K context, frontier reasoning, and agentic capabilities from StepFun |

### Research Sources
- Hugging Face API for meta-llama models (Llama-4-Scout and Llama-4-Maverick confirmed released April 2025)
- GitHub search for trending open foundation models
- StepFun AI repository discovery via web search

### Verification
All projects checked for:
- [x] OSI-approved license (Step-3.5-Flash: Apache 2.0; Llama 4: commercial license via meta-llama)
- [x] Active development (both updated April 2025)
- [x] >1000 stars (Llama 4: 7544 via llama-models, Step-3.5-Flash: 1975)
- [x] Not already in README
- [x] Fits Open Foundation Models section

### Notes
- Llama 4 released April 2025 - Meta's first native multimodal MoE architecture with open weights
- Step-3.5-Flash released March 2025 - StepFun's most capable open-source foundation model with frontier reasoning
- Both models support multimodal inputs and agentic workflows
- Complements existing GPT-OSS and Nemotron 3 entries from earlier research
