### PR TITLE
[Research] Add 1 entry to Coding & Reasoning Models — 2026-04-04

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@
 - **[CodeLlama / CodeGemma](https://github.com/facebookresearch/codellama)** ![GitHub stars](https://img.shields.io/github/stars/facebookresearch/codellama?style=social) - Meta's specialized coding variants built on Llama. Still heavily used for fine-tuning.
 - **[Qwen3-Coder-Next (Alibaba)](https://github.com/QwenLM/Qwen3-Coder)** ![GitHub stars](https://img.shields.io/github/stars/QwenLM/Qwen3-Coder?style=social) - Leading open coding model. Strong Pareto frontier for cost-effective agent deployment.
 - **[StarCoder2 (BigCode)](https://github.com/bigcode-project/starcoder2)** ![GitHub stars](https://img.shields.io/github/stars/bigcode-project/starcoder2?style=social) - 15B model trained on 600+ programming languages. Community favorite for transparency.
+- **[Granite Code Models (IBM)](https://github.com/ibm-granite/granite-code-models)** ![GitHub stars](https://img.shields.io/github/stars/ibm-granite/granite-code-models?style=social) - Family of open foundation models for code intelligence (3B–34B). Trained on 3-4T tokens of code data with strong performance across 116 programming languages.
 
 #### Multimodal Models (Vision + Language)
 


### PR DESCRIPTION
## Category: Open Foundation Models — Coding & Reasoning

Adding 1 qualifying open foundation model discovered through targeted research.

| Project | Stars | License | Why It Fits |
|---------|-------|---------|-------------|
| Granite Code Models (IBM) | 1251 | Apache 2.0 | Family of open foundation models for code intelligence (3B–34B). Trained on 3-4T tokens of code data with strong performance across 116 programming languages. |

### Research Sources
- GitHub API search for trending open foundation models
- IBM Granite organization repository discovery
- Hugging Face model hub verification

### Verification
All projects checked for:
- [x] OSI-approved license (Apache 2.0)
- [x] Active development (updated 2025)
- [x] >1000 stars (1251)
- [x] Not already in README
- [x] Fits Coding & Reasoning Models section

### Notes
- Granite Code Models were released May 2024 by IBM under Apache 2.0 license
- Models range from 3B to 34B parameters, trained specifically for code intelligence
- Supports 116 programming languages with fill-in-the-middle (FIM) code completion
- Complements existing code models in the list (StarCoder2, CodeLlama, Qwen3-Coder, DeepSeek-Coder)
