### PR TITLE
[Research] Add 2 entries to Open Foundation Models — 2026-04-04 (Period 164)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@
 - **[Phi-4 (Microsoft)](https://github.com/microsoft/PhiCookBook)** ![GitHub stars](https://img.shields.io/github/stars/microsoft/PhiCookBook?style=social) - Small but highly capable models optimized for reasoning, edge devices, and on-device inference. Includes Phi-4-reasoning variants with thinking capabilities.
 - **[GLM-5 (Zhipu AI)](https://github.com/zai-org/GLM-5)** ![GitHub stars](https://img.shields.io/github/stars/zai-org/GLM-5?style=social) - Strong open model line with solid coding, reasoning, and agentic-task performance.
 - **[OLMo 2 (Allen AI)](https://github.com/allenai/OLMo)** ![GitHub stars](https://img.shields.io/github/stars/allenai/OLMo?style=social) - Fully open-source LLMs (1B–32B) with complete transparency: models, data, training code, and logs. Designed by scientists, for scientists.
+- **[GPT-OSS (OpenAI)](https://github.com/openai/gpt-oss)** ![GitHub stars](https://img.shields.io/github/stars/openai/gpt-oss?style=social) - OpenAI's return to open-source with gpt-oss-120b and gpt-oss-20b. Apache 2.0 licensed, strong real-world performance at low cost.
 
 #### Coding & Reasoning Models
 
@@ -146,6 +147,7 @@
 - **[CodeLlama / CodeGemma](https://github.com/facebookresearch/codellama)** ![GitHub stars](https://img.shields.io/github/stars/facebookresearch/codellama?style=social) - Meta's specialized coding variants built on Llama. Still heavily used for fine-tuning.
 - **[Qwen3-Coder-Next (Alibaba)](https://github.com/QwenLM/Qwen3-Coder)** ![GitHub stars](https://img.shields.io/github/stars/QwenLM/Qwen3-Coder?style=social) - Leading open coding model. Strong Pareto frontier for cost-effective agent deployment.
 - **[StarCoder2 (BigCode)](https://github.com/bigcode-project/starcoder2)** ![GitHub stars](https://img.shields.io/github/stars/bigcode-project/starcoder2?style=social) - 15B model trained on 600+ programming languages. Community favorite for transparency.
+- **[Granite Code Models (IBM)](https://github.com/ibm-granite/granite-code-models)** ![GitHub stars](https://img.shields.io/github/stars/ibm-granite/granite-code-models?style=social) - Family of open foundation models for code intelligence. Trained on 116 programming languages with sizes from 3B to 34B parameters.
 
 #### Multimodal Models (Vision + Language)
 


### PR DESCRIPTION
## Category: Open Foundation Models (§2)

Adding 2 qualifying projects discovered through targeted research.

| Project | Stars | License | Why It Fits |
|---------|-------|---------|-------------|
| GPT-OSS (OpenAI) | 19,970 | Apache-2.0 | OpenAI's return to open-source with 120B and 20B parameter models. Strong real-world performance at low cost. |
| Granite Code Models (IBM) | 1,251 | Apache-2.0 | Family of open foundation models for code intelligence trained on 116 programming languages. |

### Research Sources
- GitHub API: Direct repository metadata check for star counts and license verification
- Verified active development (recent commits within 24 hours)
- Cross-checked against existing README to avoid duplicates

### Verification
All projects checked for:
- [x] OSI-approved license (Apache-2.0)
- [x] Active development (last updated April 4, 2026)
- [x] >1000 stars
- [x] Not already in README
- [x] Fits Open Foundation Models section