### PR TITLE
[Research] Add 2 entries to Open Foundation Models — 2026-04-04 (Period 165)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@
 - **[Phi-4 (Microsoft)](https://github.com/microsoft/PhiCookBook)** ![GitHub stars](https://img.shields.io/github/stars/microsoft/PhiCookBook?style=social) - Small but highly capable models optimized for reasoning, edge devices, and on-device inference. Includes Phi-4-reasoning variants with thinking capabilities.
 - **[GLM-5 (Zhipu AI)](https://github.com/zai-org/GLM-5)** ![GitHub stars](https://img.shields.io/github/stars/zai-org/GLM-5?style=social) - Strong open model line with solid coding, reasoning, and agentic-task performance.
 - **[OLMo 2 (Allen AI)](https://github.com/allenai/OLMo)** ![GitHub stars](https://img.shields.io/github/stars/allenai/OLMo?style=social) - Fully open-source LLMs (1B–32B) with complete transparency: models, data, training code, and logs. Designed by scientists, for scientists.
+- **[Llama 4 (Meta)](https://github.com/meta-llama/llama-models)** ![GitHub stars](https://img.shields.io/github/stars/meta-llama/llama-models?style=social) - First native multimodal MoE open-source models (Scout: 10M context, Maverick: 400B+ params). Released April 2025 with enterprise-grade capabilities.
 
 #### Coding & Reasoning Models
 
@@ -163,6 +164,7 @@
 - **[Fish Speech / StyleTTS 2](https://github.com/fishaudio/fish-speech)** ![GitHub stars](https://img.shields.io/github/stars/fishaudio/fish-speech?style=social) - Zero-shot TTS with excellent voice cloning. Extremely popular in 2026.
 - **[MusicGen / AudioCraft (Meta)](https://github.com/facebookresearch/audiocraft)** ![GitHub stars](https://img.shields.io/github/stars/facebookresearch/audiocraft?style=social) - Open music and audio generation models.
 - **[VibeVoice (Microsoft)](https://github.com/microsoft/VibeVoice)** ![GitHub stars](https://img.shields.io/github/stars/microsoft/VibeVoice?style=social) - Open-source frontier voice AI with expressive, longform conversational speech synthesis. 7B parameter TTS with streaming support.
+- **[Voxtral TTS (Mistral)](https://github.com/mistralai/mistral-inference)** ![GitHub stars](https://img.shields.io/github/stars/mistralai/mistral-inference?style=social) - 4B parameter state-of-the-art TTS with zero-shot voice cloning, 9-language support, and ~90ms time-to-first-audio for voice agents.
 
 #### Video & Animation Models
 


### PR DESCRIPTION
## Category: Open Foundation Models (§2)

Adding 2 qualifying projects discovered through targeted research.

| Project | Stars | License | Why It Fits |
|---------|-------|---------|-------------|
| Llama 4 (Meta) | 7,543 | Llama 4 Community License | First native multimodal MoE open-source models (Scout: 10M context, Maverick: 400B+ params). Major release from Meta, April 2025. |
| Voxtral TTS (Mistral) | 10,752 | Apache 2.0 | 4B parameter SOTA TTS with zero-shot voice cloning, 9-language support, and ~90ms time-to-first-audio for voice agents. |

### Research Sources
- Web search: Llama 4 Scout and Maverick release coverage (April 2025)
- Web search: Mistral Voxtral TTS announcement (March 2026)
- GitHub API: Verified stars for meta-llama/llama-models (7,543) and mistralai/mistral-inference (10,752)
- README analysis: Confirmed neither entry currently exists in the list

### Verification
All projects checked for:
- [x] OSI-approved license (or acceptable model license)
- [x] Active development
- [x] >1000 stars
- [x] Not already in README
- [x] Fits Open Foundation Models section

### Elite Tier Criteria Met
- Llama 4: Major foundation model release, multimodal MoE, 10M context window (Scout), production usage evidence
- Voxtral TTS: State-of-the-art TTS, low latency, enterprise voice agent capabilities