### PR TITLE
[Research] Add 5 elite-tier projects to RAG & Knowledge - 2026-04-05

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,12 +301,14 @@
 - **[NornicDB](https://github.com/orneryd/NornicDB)** ![GitHub stars](https://img.shields.io/github/stars/orneryd/NornicDB?style=social) - Golang Low-latency graph + vector hybrid retrieval, Neo4j and qDrant driver compatible.
 - **[LanceDB](https://github.com/lancedb/lancedb)** ![GitHub stars](https://img.shields.io/github/stars/lancedb/lancedb?style=social) - Serverless vector DB optimized for multimodal data.
 - **[pgvector](https://github.com/pgvector/pgvector)** ![GitHub stars](https://img.shields.io/github/stars/pgvector/pgvector?style=social) - PostgreSQL extension for vector similarity search.
+- **[Tantivy](https://github.com/quickwit-oss/tantivy)** ![GitHub stars](https://img.shields.io/github/stars/quickwit-oss/tantivy?style=social) - Full-text search engine library inspired by Apache Lucene, written in Rust. High-performance BM25 and hybrid search.
 
 #### Embedding Models
 
 - **[BGE (FlagEmbedding)](https://github.com/FlagOpen/FlagEmbedding)** ![GitHub stars](https://img.shields.io/github/stars/FlagOpen/FlagEmbedding?style=social) - BAAI's best-in-class embedding family.
 - **[E5 (Microsoft)](https://github.com/microsoft/unilm/tree/master/e5)** ![GitHub stars](https://img.shields.io/github/stars/microsoft/unilm?style=social) - High-performance text embeddings for retrieval.
 - **[Nomic Embed](https://github.com/nomic-ai/nomic-embed)** ![GitHub stars](https://img.shields.io/github/stars/nomic-ai/nomic-embed?style=social) - Open embedding model with long-context support and reproducible training.
+- **[model2vec](https://github.com/MinishLab/model2vec)** ![GitHub stars](https://img.shields.io/github/stars/MinishLab/model2vec?style=social) - Fast state-of-the-art static embeddings. Converts sentence transformers into efficient static models with minimal performance loss.
 
 #### RAG Frameworks & Advanced Retrieval Tools
 
@@ -323,6 +325,9 @@
 - **[RAG-Anything](https://github.com/HKUDS/RAG-Anything)** ![GitHub stars](https://img.shields.io/github/stars/HKUDS/RAG-Anything?style=social) - All-in-One Multimodal RAG system for seamless processing of text, images, tables, and equations. Built on LightRAG.
 - **[txtai](https://github.com/neuml/txtai)** ![GitHub stars](https://img.shields.io/github/stars/neuml/txtai?style=social) - All-in-one AI framework for semantic search, LLM orchestration and language model workflows. Embeddings database with customizable pipelines.
 - **[Infinity](https://github.com/michaelfeil/infinity)** ![GitHub stars](https://img.shields.io/github/stars/michaelfeil/infinity?style=social) - High-throughput, low-latency serving engine for text-embeddings, reranking, CLIP, and ColPali. OpenAI-compatible API.
+- **[Graphiti](https://github.com/getzep/graphiti)** ![GitHub stars](https://img.shields.io/github/stars/getzep/graphiti?style=social) - Real-time temporal knowledge graphs for AI agents. Hybrid retrieval combining semantic, keyword (BM25), and graph traversal with bi-temporal fact tracking.
+- **[Mem0](https://github.com/mem0ai/mem0)** ![GitHub stars](https://img.shields.io/github/stars/mem0ai/mem0?style=social) - Memory layer for AI agents and assistants. Intelligent memory management that remembers user preferences and context across conversations.
+- **[GPTCache](https://github.com/zilliztech/GPTCache)** ![GitHub stars](https://img.shields.io/github/stars/zilliztech/GPTCache?style=social) - Semantic cache for LLMs. Reduces API costs and latency by caching similar queries with vector similarity matching. Integrates with LangChain and LlamaIndex.
 
 #### Web Data Ingestion
 


### PR DESCRIPTION
## Category: RAG & Knowledge (§5)

Adding 5 elite-tier projects from research cycle.

| Project | Stars | License | Why It Fits |
|---------|-------|---------|-------------|
| Tantivy | 14,841 | MIT | Full-text search engine (Lucene-like) in Rust; powers hybrid BM25+vector search |
| model2vec | 2,020 | MIT | Fast static embeddings; converts sentence transformers to efficient production models |
| Graphiti | 24,507 | Apache-2.0 | Real-time temporal knowledge graphs with bi-temporal fact tracking for agents |
| Mem0 | 51,988 | Apache-2.0 | Memory layer for AI agents; intelligent context management across conversations |
| GPTCache | 7,974 | MIT | Semantic cache reducing LLM API costs via vector similarity matching |

### Research Sources
- GitHub trending and search
- ArXiv papers (EMNLP 2025, agent memory surveys)
- Community awesome-lists

### Verification Checklist
- [x] 1000+ stars (all projects exceed threshold)
- [x] Active development (commits within 30 days)
- [x] OSI-approved license (MIT or Apache-2.0)
- [x] Not already listed (verified against current README)
- [x] Production-ready with clear use case for RAG/Knowledge

### Notes
- Graphiti is the open-source core of Zep's commercial agent memory platform
- Mem0 is the evolution of EmbedChain (which was already popular)
- Tantivy is the search foundation for Quickwit and many vector DB hybrid search features
- All projects include comprehensive documentation and examples