### PR TITLE
Add Agent Brain to Agent Memory & State section

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@
 - **[Letta (ex-MemGPT)](https://github.com/letta-ai/letta)** ![GitHub stars](https://img.shields.io/github/stars/letta-ai/letta?style=social) - Platform for building stateful agents with advanced memory that learn and self-improve over time.
 - **[Mem0](https://github.com/mem0ai/mem0)** ![GitHub stars](https://img.shields.io/github/stars/mem0ai/mem0?style=social) - Universal memory layer for AI agents. Persistent, multi-session memory across models and environments.
 - **[Hindsight](https://github.com/vectorize-io/hindsight)** ![GitHub stars](https://img.shields.io/github/stars/vectorize-io/hindsight?style=social) - State-of-the-art long-term memory for AI agents by Vectorize. Fully self-hosted, MIT-licensed, with integrations for LangChain, CrewAI, LlamaIndex, Vercel AI SDK, and more.
+- **[Agent Brain](https://github.com/kaderosio/agent-brain)** ![GitHub stars](https://img.shields.io/github/stars/kaderosio/agent-brain?style=social) - 7-layer cognitive memory system for AI agents with perception gate, dream cycle, and predictive capabilities. Self-hostable, built with FastAPI and PostgreSQL/pgvector.
 
 ---
 


### PR DESCRIPTION
Adds [Agent Brain](https://github.com/kaderosio/agent-brain) to the Agent Memory & State section, alongside Letta, Mem0, and Hindsight.

Agent Brain is an open-source 7-layer cognitive memory system for AI agents with perception gate, dream cycle, and predictive capabilities. Self-hostable, built with FastAPI and PostgreSQL/pgvector.