### PR TITLE
Add OpenEyes - Robot vision framework for edge AI

### DIFF
--- a/EMERGING.md
+++ b/EMERGING.md
@@ -128,6 +128,7 @@
 > Domain-specific AI tools for computer vision, robotics, scientific computing, and more.
 
 - **[JaxMARL](https://github.com/FLAIROx/JaxMARL)** ![GitHub stars](https://img.shields.io/github/stars/FLAIROx/JaxMARL?style=social) - Multi-Agent Reinforcement Learning with JAX. Accelerated environments and baselines.
+- **[OpenEyes](https://github.com/mandarwagh9/openeyes)** ![GitHub stars](https://img.shields.io/github/stars/mandarwagh9/openeyes?style=social) - Hardware-agnostic robot vision framework with world models for predictive intelligence on edge devices.
 
 ---
 

--- a/EMERGING.md
+++ b/EMERGING.md
@@ -128,7 +128,6 @@
 > Domain-specific AI tools for computer vision, robotics, scientific computing, and more.
 
 - **[JaxMARL](https://github.com/FLAIROx/JaxMARL)** ![GitHub stars](https://img.shields.io/github/stars/FLAIROx/JaxMARL?style=social) - Multi-Agent Reinforcement Learning with JAX. Accelerated environments and baselines.
-- **[OpenEyes](https://github.com/mandarwagh9/openeyes)** ![GitHub stars](https://img.shields.io/github/stars/mandarwagh9/openeyes?style=social) - Hardware-agnostic robot vision framework with world models for predictive intelligence on edge devices.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@
 - **[Isaac Lab](https://github.com/isaac-sim/IsaacLab)** ![GitHub stars](https://img.shields.io/github/stars/isaac-sim/IsaacLab?style=social) - GPU-accelerated robot learning framework.
 - **[MuJoCo](https://github.com/google-deepmind/mujoco)** ![GitHub stars](https://img.shields.io/github/stars/google-deepmind/mujoco?style=social) - General-purpose physics simulator for robotics, biomechanics, and ML research. High-fidelity contact dynamics with native Python and C++ bindings. Apache 2.0 licensed.
 - **[Gymnasium (ex-OpenAI Gym)](https://github.com/Farama-Foundation/Gymnasium)** ![GitHub stars](https://img.shields.io/github/stars/Farama-Foundation/Gymnasium?style=social) - Standard RL environment API.
+- **[OpenEyes](https://github.com/mandarwagh9/openeyes)** ![GitHub stars](https://img.shields.io/github/stars/mandarwagh9/openeyes?style=social) - Hardware-agnostic robot vision framework with world models for predictive intelligence on edge devices.
 
 #### Time Series & Scientific AI
 


### PR DESCRIPTION
Add OpenEyes to Specialized Domains section in EMERGING.md

Changes:
- Add OpenEyes entry to EMERGING.md under Specialized Domains (Emerging tier)
- Add OpenEyes entry to README.md under Reinforcement Learning and Robotics (Elite tier)

- OpenEyes: Hardware-agnostic robot vision framework with world models for predictive intelligence on edge devices.