### PR TITLE
Add PaddlePaddle to Core Frameworks & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 - **[NumPyro](https://github.com/pyro-ppl/numpyro)** ![GitHub stars](https://img.shields.io/github/stars/pyro-ppl/numpyro?style=social) - Probabilistic programming with NumPy powered by JAX for autograd and JIT compilation. Bayesian modeling and inference at scale.
 - **[Keras](https://github.com/keras-team/keras)** ![GitHub stars](https://img.shields.io/github/stars/keras-team/keras?style=social) - High-level, beginner-friendly API that now runs on multiple backends (TensorFlow, JAX, PyTorch). Perfect for rapid experimentation.
 - **[tinygrad](https://github.com/tinygrad/tinygrad)** ![GitHub stars](https://img.shields.io/github/stars/tinygrad/tinygrad?style=social) - Minimalist deep learning framework with tiny code footprint. The "you like pytorch? you like micrograd? you love tinygrad!" philosophy - simple yet powerful.
+- **[PaddlePaddle](https://github.com/PaddlePaddle/Paddle)** ![GitHub stars](https://img.shields.io/github/stars/PaddlePaddle/Paddle?style=social) - Industrial deep learning platform from Baidu serving 23+ million developers and 760,000+ companies. China's first independent R&D framework with advanced distributed training and deployment capabilities.
 - **[PyTorch Geometric](https://github.com/pyg-team/pytorch_geometric)** ![GitHub stars](https://img.shields.io/github/stars/pyg-team/pytorch_geometric?style=social) - Library for deep learning on irregular input data such as graphs, point clouds, and manifolds. Part of the PyTorch ecosystem.
 
 #### Rust ML Frameworks


### PR DESCRIPTION
## Project: PaddlePaddle

### Elite Criteria Checklist (ALL Required)

- [x] **Elite Criteria:** ALL criteria met
  - ⭐ Stars: 23,812 (threshold: 1000+) ✓
  - 🔄 Active: 2026-04-11 (within 6 months) ✓
  - 🏭 Production: 23.33 million developers, 760,000 companies, 1,100,000 models ✓
  - 📚 Quality: Apache 2.0 license, comprehensive docs, active releases ✓

### Evidence of Production Usage
- Official website: https://www.paddlepaddle.org.cn/
- Serving 23.33 million developers and 760,000 companies
- Generated 1,100,000 models in production
- Widely adopted across manufacturing, agriculture, enterprise service sectors
- First independent R&D deep learning platform in China (since 2016)

### Why This Belongs in Elite Tier
PaddlePaddle is one of the "big four" deep learning frameworks alongside PyTorch, TensorFlow, and JAX. It offers:
- Industrial-grade distributed training with automatic parallelism
- Unified training and inference for large models
- High-order differentiation for scientific computing
- Massive production adoption at scale
- Active development with commits as recent as today

### Category
Core Frameworks & Libraries > Deep Learning Frameworks

### Source
Researched via GitHub API and official documentation. No existing entry found in the list.
