### PR TITLE
Add 2 elite-tier IDE plugins to Developer Tools & Integrations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,6 +749,8 @@
 - **[llama.vim](https://github.com/ggml-org/llama.vim)** ![GitHub stars](https://img.shields.io/github/stars/ggml-org/llama.vim?style=social) - Local LLM-powered code completion plugin for Vim/Neovim using llama.cpp. Fast, privacy-first, no API key needed.
 - **[CodeCompanion.nvim](https://github.com/olimorris/codecompanion.nvim)** ![GitHub stars](https://img.shields.io/github/stars/olimorris/codecompanion.nvim?style=social) - AI-powered coding assistant for Neovim. Inline code generation, chat, actions, and tool use with support for multiple LLM providers.
 - **[Continue VS Code / JetBrains](https://github.com/continuedev/continue)** ![GitHub stars](https://img.shields.io/github/stars/continuedev/continue?style=social) - Most installed open-source AI extension.
+- **[avante.nvim](https://github.com/yetone/avante.nvim)** ![GitHub stars](https://img.shields.io/github/stars/yetone/avante.nvim?style=social) - Neovim plugin that brings Cursor-like AI IDE features to Vim. Edit code with natural language, generate code from context, and chat with AI about your codebase. Apache 2.0 licensed.
+- **[windsurf.vim](https://github.com/Exafunction/windsurf.vim)** ![GitHub stars](https://img.shields.io/github/stars/Exafunction/windsurf.vim?style=social) - Free, ultrafast Copilot alternative for Vim and Neovim. AI-powered code completion with low latency and large context window. MIT licensed.
 - **[Jupyter AI](https://github.com/jupyterlab/jupyter-ai)** ![GitHub stars](https://img.shields.io/github/stars/jupyterlab/jupyter-ai?style=social) - Chat and code generation inside notebooks.
 
 #### UI Components & Chat Libraries


### PR DESCRIPTION
This PR adds 2 elite-tier open-source AI coding tools to the Developer Tools & Integrations (§13) section under IDE Plugins & Extensions.

## Projects Added

### 1. avante.nvim
- **Repository:** yetone/avante.nvim
- **Stars:** ~17.8k
- **License:** Apache 2.0 ✅
- **Description:** Neovim plugin that brings Cursor-like AI IDE features to Vim. Edit code with natural language, generate code from context, and chat with AI about your codebase.
- **Activity:** Last updated March 30, 2026 (within 6 months)

### 2. windsurf.vim
- **Repository:** Exafunction/windsurf.vim
- **Stars:** ~5.1k
- **License:** MIT ✅
- **Description:** Free, ultrafast Copilot alternative for Vim and Neovim. AI-powered code completion with low latency and large context window.
- **Activity:** Last updated March 31, 2026 (within 6 months)

## Qualification Criteria Met
- ✅ 1000+ GitHub stars (both projects exceed threshold)
- ✅ Active development (commits within last 6 months)
- ✅ OSI-approved licenses (Apache 2.0 and MIT)
- ✅ Production-ready tools with real-world adoption
- ✅ Well-documented with professional-grade quality

## Validation
- [x] Local validation passed (
== Structural checks ==
ok

== Remote GitHub checks ==
ok

== Notes ==
- remote validation skipped via --skip-remote

Summary: 0 error(s), 0 warning(s))
- [x] No duplicate entries
- [x] Proper formatting matches existing entries
- [x] Single-category PR as per guidelines