### PR TITLE
Add InternLM3 to Open Foundation Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@
 - **[OLMo 2 (Allen AI)](https://github.com/allenai/OLMo)** ![GitHub stars](https://img.shields.io/github/stars/allenai/OLMo?style=social) - Fully open-source LLMs (1B–32B) with complete transparency: models, data, training code, and logs. Designed by scientists, for scientists.
 - **[Llama 4 (Meta)](https://github.com/meta-llama/llama-models)** ![GitHub stars](https://img.shields.io/github/stars/meta-llama/llama-models?style=social) - First native multimodal MoE open-source models (Scout: 10M context, Maverick: 400B+ params). Released April 2025 with enterprise-grade capabilities.
 - **[GPT-OSS (OpenAI)](https://github.com/openai/gpt-oss)** ![GitHub stars](https://img.shields.io/github/stars/openai/gpt-oss?style=social) - OpenAI's first open-weight models since GPT-2 (120B and 20B MoE). Apache 2.0 licensed with state-of-the-art performance for their size class. Released August 2025.
+- **[InternLM3 (Shanghai AI Lab)](https://github.com/InternLM/InternLM)** ![GitHub stars](https://img.shields.io/github/stars/InternLM/InternLM?style=social) - 8B parameter instruction model with state-of-the-art performance on reasoning and knowledge-intensive tasks. Trained on only 4 trillion tokens (75% cost savings). Supports deep thinking mode via long chain-of-thought. Apache 2.0 licensed.
 
 #### Coding & Reasoning Models
 


### PR DESCRIPTION
## Add InternLM3 to Open Foundation Models

### Project Details
| Field | Value |
|-------|-------|
| **Name** | InternLM3 |
| **Repository** | https://github.com/InternLM/InternLM |
| **Stars** | 7,185⭐ |
| **License** | Apache-2.0 |
| **Last Activity** | October 2025 |
| **Category** | Open Foundation Models (§2) |

### Why This Project

InternLM3 is a notable missing elite-tier open foundation model:

- **State-of-the-art efficiency**: 8B parameter instruction model trained on only 4 trillion high-quality tokens, achieving 75% training cost savings compared to similar-scale LLMs
- **Strong performance**: Surpasses Llama3.1-8B and Qwen2.5-7B on reasoning and knowledge-intensive tasks
- **Dual-mode capability**: Supports both deep thinking mode (long chain-of-thought for complex reasoning) and normal response mode for fluent interactions
- **Production-ready**: Apache-2.0 licensed with active development from Shanghai AI Lab
- **Community validation**: 7,185+ GitHub stars with ongoing releases (InternLM3-8B-Instruct released January 2025)

### Qualification Checklist

- [x] 1000+ GitHub stars (7,185⭐)
- [x] Active within last 6 months (last push October 2025)
- [x] OSI-approved license (Apache-2.0)
- [x] Evidence of production use (widely used in Chinese AI ecosystem, integrated with LMDeploy and XTuner)
- [x] Quality documentation and model cards

### Related Projects Already in List
- LMDeploy (InternLM's deployment toolkit) - already listed in Inference Engines
- XTuner (InternLM's training engine) - already listed in Training & Fine-tuning

This PR adds the foundation model itself to complete the InternLM ecosystem representation.
