### PR TITLE
Add CTranslate2 and DeepSpeed-MII to Inference Engines & Serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,11 @@
 - **[OpenLLM (BentoML)](https://github.com/bentoml/OpenLLM)** ![GitHub stars](https://img.shields.io/github/stars/bentoml/OpenLLM?style=social) - Production-grade platform for running any open-source LLMs as OpenAI-compatible API endpoints. Supports 50+ models with built-in streaming, batching, and auto-acceleration. Apache 2.0 licensed.
 - **[Higress (Alibaba)](https://github.com/alibaba/higress)** ![GitHub stars](https://img.shields.io/github/stars/alibaba/higress?style=social) - AI-native API gateway born from Alibaba's internal infrastructure with 2+ years of production validation. Provides unified LLM API and MCP (Model Context Protocol) management with enterprise-grade 99.99% availability. Apache 2.0 licensed.
 
+#### Additional Inference Engines
+
+- **[CTranslate2](https://github.com/OpenNMT/CTranslate2)** ![GitHub stars](https://img.shields.io/github/stars/OpenNMT/CTranslate2?style=social) - Fast inference engine for Transformer models supporting OpenNMT and Hugging Face models. Optimized for CPU and GPU with batching, quantization (INT8/FP16), and dynamic memory management. Powers faster-whisper and other production deployments. MIT licensed.
+- **[DeepSpeed-MII](https://github.com/deepspeedai/DeepSpeed-MII)** ![GitHub stars](https://img.shields.io/github/stars/deepspeedai/DeepSpeed-MII?style=social) - Microsoft's low-latency and high-throughput inference serving framework. Enables efficient model deployment with built-in load balancing, multi-GPU tensor parallelism, and RESTful/gRPC APIs. Integrates with DeepSpeed for production-scale serving. Apache 2.0 licensed.
+
 #### Quantization, Distillation & Optimization
 
 - **[GGUF](https://github.com/ggerganov/llama.cpp)** ![GitHub stars](https://img.shields.io/github/stars/ggerganov/llama.cpp?style=social) (part of llama.cpp) - Modern quantized format that powers most local inference.


### PR DESCRIPTION
## Add CTranslate2 and DeepSpeed-MII to Inference Engines & Serving

This PR adds 2 elite-tier inference engine projects to the **Inference Engines & Serving** category:

### Added Projects

1. **[CTranslate2](https://github.com/OpenNMT/CTranslate2)** (4,424⭐, MIT license, active Feb 2026)
   - Fast inference engine for Transformer models supporting OpenNMT and Hugging Face models
   - Optimized for CPU and GPU with batching, quantization (INT8/FP16), and dynamic memory management
   - Powers faster-whisper and other production deployments

2. **[DeepSpeed-MII](https://github.com/deepspeedai/DeepSpeed-MII)** (2,107⭐, Apache-2.0, active June 2025)
   - Microsoft's low-latency and high-throughput inference serving framework
   - Enables efficient model deployment with built-in load balancing, multi-GPU tensor parallelism, and RESTful/gRPC APIs
   - Integrates with DeepSpeed for production-scale serving

### Qualification Criteria Met

| Project | Stars | Activity | License | Production Use |
|---------|-------|----------|---------|----------------|
| CTranslate2 | 4,424⭐ | Feb 2026 | MIT | Powers faster-whisper |
| DeepSpeed-MII | 2,107⭐ | June 2025 | Apache-2.0 | Microsoft production stack |

Both projects exceed the 1000+ star threshold, have OSI-approved licenses, and show active development within the last 6 months.

### Validation

- [x] `python3 tools/validate_awesome.py --skip-remote` passes with 0 errors
- [x] Single-category PR (Inference Engines & Serving only)
- [x] Non-structural changes (entry additions only)
- [x] README.md only modified

---
**Research Loop:** Category 2 (Inference Engines & Serving) - 2026-04-13