### PR TITLE
Add Octopal to autonomous coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@
 - **[Pi (badlogic)](https://github.com/badlogic/pi-mono)** ![GitHub stars](https://img.shields.io/github/stars/badlogic/pi-mono?style=social) - Terminal coding agent with hash-anchored edits, LSP integration, subagents, MCP support, and package ecosystem.
 - **[Mistral-Vibe (Mistral)](https://github.com/mistralai/mistral-vibe)** ![GitHub stars](https://img.shields.io/github/stars/mistralai/mistral-vibe?style=social) - Minimal CLI coding agent by Mistral. Lightweight, fast, and designed for local development workflows.
 - **[Nanocoder (Nano-Collective)](https://github.com/Nano-Collective/nanocoder)** ![GitHub stars](https://img.shields.io/github/stars/Nano-Collective/nanocoder?style=social) - Beautiful local-first coding agent running in your terminal. Built for privacy and control with support for multiple AI providers via OpenRouter.
+- **[Octopal](https://github.com/pmbstyle/Octopal)** ![GitHub stars](https://img.shields.io/github/stars/pmbstyle/Octopal?style=social) - Security-first local multi-agent runtime with isolated workers, policy-controlled execution, built-in tools/MCP support, recurring tasks, and a private dashboard for autonomous operations.
 - **[Gemini CLI (Google)](https://github.com/google-gemini/gemini-cli)** ![GitHub stars](https://img.shields.io/github/stars/google-gemini/gemini-cli?style=social) - Open-source AI agent that brings Gemini's power directly into your terminal. Supports code generation, shell execution, and file editing with full Apache 2.0 licensing.
 
 #### Domain-Specific Agents


### PR DESCRIPTION
## Summary
- add Octopal under Autonomous Coding Agents
- highlight its security-first local runtime and MCP/tool support

## Why
Octopal is an open-source local runtime for autonomous agent operations and belongs in the agentic AI section.