### PR TITLE
Add KitOps to MLOps / LLMOps & Production category

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,7 @@
 - **[Kubeflow Pipelines](https://github.com/kubeflow/pipelines)** ![GitHub stars](https://img.shields.io/github/stars/kubeflow/pipelines?style=social) - Machine Learning Pipelines for Kubeflow. Platform for building and deploying portable, scalable ML workflows using Kubernetes and Argo. Apache 2.0 licensed.
 - **[MLRun](https://github.com/mlrun/mlrun)** ![GitHub stars](https://img.shields.io/github/stars/mlrun/mlrun?style=social) - Open-source AI orchestration platform for quickly building and managing continuous ML and generative AI applications across their lifecycle. Automates data preparation, model tuning, and deployment. Apache 2.0 licensed.
 - **[Kestra](https://github.com/kestra-io/kestra)** ![GitHub stars](https://img.shields.io/github/stars/kestra-io/kestra?style=social) - Event-driven orchestration and scheduling platform for mission-critical workflows. Infrastructure-as-Code approach with declarative YAML, Git version control integration, and hundreds of plugins for data pipelines and ML workflows. Apache 2.0 licensed.
+- **[KitOps](https://github.com/kitops-ml/kitops)** ![GitHub stars](https://img.shields.io/github/stars/kitops-ml/kitops?style=social) - CNCF open source DevOps tool for packaging, versioning, and securely sharing AI/ML models, datasets, code, and configuration into OCI artifacts. Integrates with existing container registries and CI/CD pipelines. Apache 2.0 licensed.
 
 #### Feature Engineering & Data Preparation
 


### PR DESCRIPTION
## Summary

This PR adds **KitOps** to the MLOps / LLMOps & Production category under the "Deployment & Orchestration" subsection.

## Project Details

**KitOps** (1,330⭐, Apache-2.0, active Apr 2026)
- CNCF open source DevOps tool for packaging, versioning, and securely sharing AI/ML models, datasets, code, and configuration
- Packages everything into OCI (Open Container Initiative) artifacts stored in existing container registries
- Integrates with CI/CD pipelines and existing DevOps workflows
- Enables immutable, self-contained ModelKits for reproducible AI deployments
- Supports artifact signing, AI SBOM creation, and tamper-proof versioning

## Why Add This Project

The MLOps section already has excellent coverage of experiment tracking, orchestration, and monitoring tools. KitOps fills a unique gap in **model packaging and versioning** - specifically addressing the challenge of bundling models with their dependencies (datasets, code, config) into versioned, portable artifacts. This is increasingly critical as organizations move toward production AI deployments that require reproducibility and security.

## Checklist

- [x] OSI-approved license (Apache-2.0)
- [x] 1000+ GitHub stars (1,330)
- [x] Active within last 6 months (last push Apr 13, 2026)
- [x] Production-ready with real-world use
- [x] Validation passed (0 errors, 0 warnings)