### PR TITLE
Add elite inference engines: PowerInfer, TGI, DeepSpeed-MII

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@
 - **[KoboldCpp](https://github.com/LostRuins/koboldcpp)** ![GitHub stars](https://img.shields.io/github/stars/LostRuins/koboldcpp?style=social) - User-friendly llama.cpp fork focused on role-playing and creative writing.
 - **[RamaLama](https://github.com/containers/ramalama)** ![GitHub stars](https://img.shields.io/github/stars/containers/ramalama?style=social) - Container-centric tool for simplifying local AI model serving. Automatically detects GPUs, pulls optimized container images, and runs models securely in rootless containers with enterprise-grade isolation.
 - **[LiteRT-LM](https://github.com/google-ai-edge/LiteRT-LM)** ![GitHub stars](https://img.shields.io/github/stars/google-ai-edge/LiteRT-LM?style=social) - Google's production-ready inference framework for deploying LLMs on edge devices. Cross-platform support for Android, iOS, Web, Desktop, and IoT with GPU/NPU acceleration. Powers on-device GenAI in Chrome and Chromebook Plus. Apache 2.0 licensed.
+- **[PowerInfer](https://github.com/SJTU-IPADS/PowerInfer)** ![GitHub stars](https://img.shields.io/github/stars/SJTU-IPADS/PowerInfer?style=social) - High-speed LLM inference engine for local deployment on consumer-grade GPUs. Achieves up to 11x speedup over llama.cpp on PCs with limited VRAM through hot/cold neuron caching. MIT licensed.
 
 #### High-performance Serving & API Servers
 
@@ -261,6 +262,8 @@
 - **[One-API](https://github.com/songquanpeng/one-api)** ![GitHub stars](https://img.shields.io/github/stars/songquanpeng/one-api?style=social) - LLM API management and key redistribution system. Unifies multiple providers (OpenAI, Anthropic, Azure, etc.) under a single OpenAI-compatible API with built-in rate limiting, quota management, and cost tracking. MIT licensed.
 - **[OpenLLM (BentoML)](https://github.com/bentoml/OpenLLM)** ![GitHub stars](https://img.shields.io/github/stars/bentoml/OpenLLM?style=social) - Production-grade platform for running any open-source LLMs as OpenAI-compatible API endpoints. Supports 50+ models with built-in streaming, batching, and auto-acceleration. Apache 2.0 licensed.
 - **[Higress (Alibaba)](https://github.com/alibaba/higress)** ![GitHub stars](https://img.shields.io/github/stars/alibaba/higress?style=social) - AI-native API gateway born from Alibaba's internal infrastructure with 2+ years of production validation. Provides unified LLM API and MCP (Model Context Protocol) management with enterprise-grade 99.99% availability. Apache 2.0 licensed.
+- **[Text Generation Inference (TGI)](https://github.com/huggingface/text-generation-inference)** ![GitHub stars](https://img.shields.io/github/stars/huggingface/text-generation-inference?style=social) - Hugging Face's production-grade LLM serving framework. Powers thousands of production deployments with continuous batching, flash attention, and optimized quantization. Apache 2.0 licensed.
+- **[DeepSpeed-MII](https://github.com/deepspeedai/DeepSpeed-MII)** ![GitHub stars](https://img.shields.io/github/stars/deepspeedai/DeepSpeed-MII?style=social) - Microsoft's low-latency and high-throughput inference engine. Dynamic SplitFuse scheduling for up to 2.5x throughput improvement over vLLM on supported models. Apache 2.0 licensed.
 
 #### Additional Inference Engines
 


### PR DESCRIPTION
## Research Category: Inference Engines & Serving (§3)

This PR adds 3 elite-tier open-source inference engines that meet all qualification criteria (1000+ stars, active development, OSI-approved licenses).

### Additions

1. **PowerInfer** (9,331 stars, MIT license)
   - High-speed LLM inference engine for local deployment on consumer-grade GPUs
   - Achieves up to 11x speedup over llama.cpp on PCs with limited VRAM
   - Uses hot/cold neuron caching for efficient memory utilization
   - Repository: https://github.com/SJTU-IPADS/PowerInfer

2. **Text Generation Inference (TGI)** (10,832 stars, Apache-2.0)
   - Hugging Face's production-grade LLM serving framework
   - Powers thousands of production deployments
   - Features continuous batching, flash attention, and optimized quantization
   - Repository: https://github.com/huggingface/text-generation-inference

3. **DeepSpeed-MII** (2,108 stars, Apache-2.0)
   - Microsoft's low-latency and high-throughput inference engine
   - Dynamic SplitFuse scheduling for up to 2.5x throughput improvement over vLLM
   - Part of Microsoft's DeepSpeed ecosystem
   - Repository: https://github.com/deepspeedai/DeepSpeed-MII

### Validation
- [x] All projects have 1000+ GitHub stars
- [x] All projects have OSI-approved licenses
- [x] All projects show active development (commits within last 6 months)
- [x] Structural validation passed
- [x] Single category only (Inference Engines & Serving)
- [x] Non-structural changes only (entry additions)