### PR TITLE
Add Vectara Hallucination Leaderboard to Evaluation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Awesome Open Source AI
 
-*A curated list of **battle-tested, production-proven** open-source AI models, libraries, infrastructure, and developer tools. Only elite-tier projects make this list. Updated April 18, 2026.*
+*A curated list of **battle-tested, production-proven** open-source AI models, libraries, infrastructure, and developer tools. Only elite-tier projects make this list. Updated April 19, 2026.*
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](./CONTRIBUTING.md)
@@ -682,6 +682,7 @@
 - **[MLPerf Training](https://github.com/mlcommons/training)** ![GitHub stars](https://img.shields.io/github/stars/mlcommons/training?style=social) - Industry-standard ML training benchmarks from MLCommons. Reference implementations for training AI models at scale across image classification, object detection, NLP, and recommendation tasks. Apache 2.0 licensed.
 - **[VLMEvalKit](https://github.com/open-compass/VLMEvalKit)** ![GitHub stars](https://img.shields.io/github/stars/open-compass/VLMEvalKit?style=social) - Open-source evaluation toolkit for large multi-modality models (LMMs). Supports 220+ LMMs and 80+ benchmarks including MMMU, MathVista, and ChartQA. Powers the OpenVLM Leaderboard. Apache 2.0 licensed.
 - **[MTEB](https://github.com/embeddings-benchmark/mteb)** ![GitHub stars](https://img.shields.io/github/stars/embeddings-benchmark/mteb?style=social) - Massive Text Embedding Benchmark. The standard evaluation suite for text embeddings with 1000+ evaluation tasks and an interactive leaderboard. Powers the Hugging Face Embedding Leaderboard. Apache 2.0 licensed.
+- **[Vectara Hallucination Leaderboard](https://github.com/vectara/hallucination-leaderboard)** ![GitHub stars](https://img.shields.io/github/stars/vectara/hallucination-leaderboard?style=social) - Leaderboard comparing LLM performance at producing hallucinations when summarizing short documents. Systematic evaluation of factual consistency across major models. Apache 2.0 licensed.
 - **[SWE-rebench (Nebius)](https://huggingface.co/datasets/nebius/SWE-rebench)** - Continuously updated benchmark with 21,000+ real-world SWE tasks for evaluating agentic LLMs. Decontaminated, mined from GitHub.
 - **[AgentBench (THUDM)](https://github.com/THUDM/AgentBench)** ![GitHub stars](https://img.shields.io/github/stars/THUDM/AgentBench?style=social) - Comprehensive benchmark to evaluate LLMs as agents across 8 diverse environments including household, web shopping, OS interaction, and database tasks. ICLR 2024. Apache 2.0 licensed.
 


### PR DESCRIPTION
## Research: Evaluation & Benchmarking

This PR adds the **Vectara Hallucination Leaderboard** to the Evaluation, Benchmarks & Datasets section.

### Project Added

- **[Vectara Hallucination Leaderboard](https://github.com/vectara/hallucination-leaderboard)** - Leaderboard comparing LLM performance at producing hallucinations when summarizing short documents. Systematic evaluation of factual consistency across major models.

### Elite Criteria Verification

| Criteria | Status |
|----------|--------|
| Stars | ✅ 3,194 |
| Activity | ✅ Last pushed 2026-04-17 |
| License | ✅ Apache 2.0 |
| Quality | ✅ Production-ready benchmark |

### Research Summary

The Evaluation & Benchmarking category is already well-covered in the repository with most major evaluation frameworks already present:
- lm-evaluation-harness, OpenCompass, DeepEval, RAGAs, OpenAI Evals, LMMs-Eval, Phoenix, OpenEvals, etc.

The Vectara Hallucination Leaderboard was identified as the only additional elite-tier project (1000+ stars, active, OSI license) not already included in the list. It provides unique value as a specialized benchmark for measuring hallucinations in summarization tasks.

---
*Automated research loop run on 2026-04-19*