### PR TITLE
Add AI Development Tools: Void Editor, Open Notebook, Deta Surf, and update Aider URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,6 +940,7 @@
 #### AI-Native IDEs & Development Environments
 
 - **[Zed](https://github.com/zed-industries/zed)** ![GitHub stars](https://img.shields.io/github/stars/zed-industries/zed?style=social) - High-performance, multiplayer code editor with built-in AI features. From the creators of Atom and Tree-sitter. Native AI agentic editing with support for any LLM provider. GPL licensed.
+- **[Void Editor](https://github.com/voideditor/void)** ![GitHub stars](https://img.shields.io/github/stars/voideditor/void?style=social) - Open-source AI-native code editor forked from VS Code. Features agentic AI editing, inline code generation, and chat interface. Designed as a Cursor alternative with full control over your data. Apache 2.0 licensed.
 - **[Code Server](https://github.com/coder/code-server)** ![GitHub stars](https://img.shields.io/github/stars/coder/code-server?style=social) - Run VS Code on any machine anywhere and access it in the browser. Self-hosted cloud IDE with full extension support. MIT licensed.
 - **[Gitpod](https://github.com/gitpod-io/gitpod)** ![GitHub stars](https://img.shields.io/github/stars/gitpod-io/gitpod?style=social) - Cloud development environment platform with automated prebuilds, ephemeral workspaces, and support for any IDE. Self-hostable with open-source core. AGPL-3.0 licensed.
 
@@ -950,11 +951,13 @@
 - **[Cline](https://github.com/cline/cline)** ![GitHub stars](https://img.shields.io/github/stars/cline/cline?style=social) - Open-source IDE coding agent that can edit files, run commands, and use tools with user approval.
 - **[Open Interpreter](https://github.com/OpenInterpreter/open-interpreter)** ![GitHub stars](https://img.shields.io/github/stars/OpenInterpreter/open-interpreter?style=social) - Lets LLMs run code locally.
 - **[Roo Code](https://github.com/RooCodeInc/Roo-Code)** ![GitHub stars](https://img.shields.io/github/stars/RooCodeInc/Roo-Code?style=social) - Open-source editor-based coding agent with multiple modes and tool integrations.
-- **[Aider](https://github.com/paul-gauthier/aider)** ![GitHub stars](https://img.shields.io/github/stars/paul-gauthier/aider?style=social) - Terminal-based AI pair programmer.
+- **[Aider](https://github.com/Aider-AI/aider)** ![GitHub stars](https://img.shields.io/github/stars/Aider-AI/aider?style=social) - Terminal-based AI pair programmer. Edit code in your local editor and aider implements the changes. Supports multiple LLMs, voice coding, and automatic git commits. Top scores on SWE Bench. Apache 2.0 licensed.
 - **[Refact](https://github.com/smallcloudai/refact)** ![GitHub stars](https://img.shields.io/github/stars/smallcloudai/refact?style=social) - Open-source AI code assistant with autocomplete, chat, and refactoring. Self-hostable with support for multiple LLM providers. BSD-3-Clause licensed.
 
 #### Notebooks & Interactive Computing
 
+- **[Open Notebook](https://github.com/lfnovo/open-notebook)** ![GitHub stars](https://img.shields.io/github/stars/lfnovo/open-notebook?style=social) - Open-source implementation of Notebook LM with multi-modal content support (PDFs, videos, audio, web pages). Features multi-speaker podcast generation, 18+ AI provider integrations, and full-text + vector search. Self-hosted with complete data sovereignty. MIT licensed.
+- **[Deta Surf](https://github.com/deta/surf)** ![GitHub stars](https://img.shields.io/github/stars/deta/surf?style=social) - Personal AI notebook for organizing files and webpages with AI-generated notes. Local-first data storage, open data formats, and open model choice including local models. Cross-platform desktop app for research and thinking workflows. Apache 2.0 licensed.
 - **[Quarto](https://github.com/quarto-dev/quarto-cli)** ![GitHub stars](https://img.shields.io/github/stars/quarto-dev/quarto-cli?style=social) - Open-source scientific and technical publishing system built on Pandoc. Create dynamic content with Python, R, Julia, and Observable. MIT licensed.
 
 #### IDE Plugins & Extensions


### PR DESCRIPTION
## 🧪 Category: AI Development Tools

This PR adds elite-tier open-source AI development tools and updates an existing entry.

### New Additions

**AI-Native IDEs & Development Environments:**
- **[Void Editor](https://github.com/voideditor/void)** (28.6k stars) - Open-source AI-native code editor forked from VS Code. Apache 2.0 licensed. Active development.

**Notebooks & Interactive Computing:**
- **[Open Notebook](https://github.com/lfnovo/open-notebook)** (22.4k stars) - Open-source implementation of Notebook LM. MIT licensed. Active development.
- **[Deta Surf](https://github.com/deta/surf)** (3.3k stars) - Personal AI notebook for organizing files and webpages. Apache 2.0 licensed. Active development.

### Updates
- **Aider**: Updated repository URL from 

## Verification

All projects meet the elite-tier criteria:
- ✅ 1000+ GitHub stars
- ✅ Active development (commits within last 3 months)
- ✅ OSI-approved open source license
- ✅ Production-ready with documentation