### PR TITLE
Add Meilisearch and Typesense to Vector Databases section

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,8 @@
 - **[Annoy](https://github.com/spotify/annoy)** ![GitHub stars](https://img.shields.io/github/stars/spotify/annoy?style=social) - Approximate nearest neighbors library optimized for memory usage and fast loading. Powers Spotify's music recommendation with C++/Python bindings. Apache 2.0 licensed.
 - **[sqlite-vec](https://github.com/asg017/sqlite-vec)** ![GitHub stars](https://img.shields.io/github/stars/asg017/sqlite-vec?style=social) - A vector search SQLite extension that runs anywhere. Extremely small, "fast enough" vector search written in pure C with no dependencies. Perfect for embedded and edge deployments. MIT/Apache-2.0 dual licensed.
 - **[zvec](https://github.com/alibaba/zvec)** ![GitHub stars](https://img.shields.io/github/stars/alibaba/zvec?style=social) - Lightweight, lightning-fast, in-process vector database from Alibaba. Built on Proxima (Alibaba's battle-tested vector search engine) for production-grade, low-latency similarity search. Apache 2.0 licensed.
+- **[Meilisearch](https://github.com/meilisearch/meilisearch)** ![GitHub stars](https://img.shields.io/github/stars/meilisearch/meilisearch?style=social) - Lightning-fast search engine API with AI-powered hybrid search. Features typo-tolerant full-text search combined with HNSW-based vector search for semantic retrieval. MIT licensed.
+- **[Typesense](https://github.com/typesense/typesense)** ![GitHub stars](https://img.shields.io/github/stars/typesense/typesense?style=social) - Open source alternative to Algolia + Pinecone. Fast, typo-tolerant, in-memory fuzzy search engine with native vector search capabilities. GPL-3.0 licensed.
 
 #### Embedding Models
 


### PR DESCRIPTION
## Summary

This PR adds two elite-tier vector search engines to the **Vector Databases & Search Engines** section:

### Added Projects

1. **[Meilisearch](https://github.com/meilisearch/meilisearch)** (57k+ stars)
   - Lightning-fast search engine API with AI-powered hybrid search
   - Features typo-tolerant full-text search combined with HNSW-based vector search
   - MIT licensed
   - Actively maintained with recent releases

2. **[Typesense](https://github.com/typesense/typesense)** (23k+ stars)
   - Open source alternative to Algolia + Pinecone
   - Fast, typo-tolerant, in-memory fuzzy search engine with native vector search
   - GPL-3.0 licensed
   - Production-ready with 10B+ searches/month served

### Criteria Met

Both projects satisfy the OSAI elite-tier requirements:
- ✅ 1000+ GitHub stars (57k and 23k respectively)
- ✅ Active development (commits within last 3 months)
- ✅ OSI-approved open source licenses (MIT and GPL-3.0)
- ✅ Production-ready with documented vector search capabilities
- ✅ Well-documented with active community support

### Notes

These additions complement the existing vector database entries by adding popular search-engine-first solutions that have evolved to include vector search capabilities, providing users with more options for hybrid (keyword + semantic) search use cases.