### PR TITLE
Add UpTrain and Prometheus-eval to Evaluation & Benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,6 +739,8 @@
 - **[BrowserGym](https://github.com/ServiceNow/BrowserGym)** ![GitHub stars](https://img.shields.io/github/stars/ServiceNow/BrowserGym?style=social) - Gym environment for web task automation and agent evaluation. Includes MiniWoB, WebArena, WorkArena, and more. Apache 2.0 licensed.
 - **[TruLens](https://github.com/truera/trulens)** ![GitHub stars](https://img.shields.io/github/stars/truera/trulens?style=social) - Evaluation and tracking for LLM experiments and AI agents. Provides feedback functions for measuring quality, relevance, and groundedness with LangChain and LlamaIndex integrations. MIT licensed.
 - **[OpenEvals](https://github.com/langchain-ai/openevals)** ![GitHub stars](https://img.shields.io/github/stars/langchain-ai/openevals?style=social) - Open-source evaluation library for LLM and agent applications. Built by LangChain with pre-built evaluators for common use cases including RAG, agents, and structured output validation. MIT licensed.
+- **[UpTrain](https://github.com/uptrain-ai/uptrain)** ![GitHub stars](https://img.shields.io/github/stars/uptrain-ai/uptrain?style=social) - Open-source unified platform to evaluate and improve Generative AI applications. 20+ preconfigured checks for language, code, and embedding use-cases with root cause analysis. Apache 2.0 licensed.
+- **[Prometheus-eval](https://github.com/prometheus-eval/prometheus-eval)** ![GitHub stars](https://img.shields.io/github/stars/prometheus-eval/prometheus-eval?style=social) - Open-source language models specialized in evaluating other language models. Supports absolute (1-5) and relative (A/B) grading with customizable rubrics. Apache 2.0 licensed.
 
 #### High-quality Open Datasets & Data Tools
 


### PR DESCRIPTION
## Summary

This PR adds 2 elite-tier evaluation frameworks to Section 9 (Evaluation, Benchmarks & Datasets):

### Added Projects

1. **[UpTrain](https://github.com/uptrain-ai/uptrain)** (2.3K+ stars)
   - Open-source unified platform for evaluating and improving Generative AI applications
   - 20+ preconfigured checks covering language, code, and embedding use-cases
   - Root cause analysis on failure cases with actionable insights
   - Apache 2.0 licensed, actively maintained

2. **[Prometheus-eval](https://github.com/prometheus-eval/prometheus-eval)** (1.1K+ stars)
   - Open-source language models specialized in evaluating other LLMs
   - Supports both absolute grading (1-5 scale) and relative grading (A/B comparison)
   - Customizable rubrics and reference answer support
   - Latest M-Prometheus variants with multilingual evaluation capabilities
   - Apache 2.0 licensed, actively maintained

### Research Notes

Category already comprehensively covered with 20+ elite-tier evaluation frameworks including: lm-evaluation-harness, OpenCompass, DeepEval, Inspect AI, RAGAs, Lighteval, Hugging Face Evaluate, OpenAI Evals, LMMs-Eval, FlashRAG, BrowserGym, TruLens, OpenEvals, LiveBench, SWE-bench, GAIA, MLPerf Inference/Training, VLMEvalKit, MTEB, Vectara Hallucination Leaderboard, SWE-rebench, AgentBench.

**Excluded:** Phoenix (Arize) - already listed in MLOps section, uses Elastic License 2.0 (not OSI-approved).

All added projects meet the elite criteria: 1000+ stars, active development, OSI-approved license, production-ready quality.