### PR TITLE
Add elite-tier RAG frameworks: STORM and R2R

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,8 @@
 #### RAG Frameworks & Advanced Retrieval Tools
 
 - **[LlamaIndex](https://github.com/run-llama/llama_index)** ![GitHub stars](https://img.shields.io/github/stars/run-llama/llama_index?style=social) - Full-featured RAG pipeline with advanced indexing.
+- **[STORM (Stanford)](https://github.com/stanford-oval/storm)** ![GitHub stars](https://img.shields.io/github/stars/stanford-oval/storm?style=social) - LLM-powered knowledge curation system that researches topics and generates full-length reports with citations. MIT licensed.
+- **[R2R (SciPhi)](https://github.com/SciPhi-AI/R2R)** ![GitHub stars](https://img.shields.io/github/stars/SciPhi-AI/R2R?style=social) - Production-ready agentic RAG engine with RESTful API. Features hybrid search, knowledge graphs, multimodal RAG, and deep research capabilities. MIT licensed.
 - **[Haystack](https://github.com/deepset-ai/haystack)** ![GitHub stars](https://img.shields.io/github/stars/deepset-ai/haystack?style=social) - End-to-end NLP and RAG framework.
 - **[RAGFlow](https://github.com/infiniflow/ragflow)** ![GitHub stars](https://img.shields.io/github/stars/infiniflow/ragflow?style=social) - Deep-document-understanding RAG engine.
 - **[GraphRAG (Microsoft)](https://github.com/microsoft/graphrag)** ![GitHub stars](https://img.shields.io/github/stars/microsoft/graphrag?style=social) - Knowledge-graph-based RAG.


### PR DESCRIPTION
## Summary

This PR adds 2 elite-tier RAG (Retrieval-Augmented Generation) frameworks to the "RAG & Knowledge" section:

### Added Projects

1. **STORM (Stanford)** - 28,118 stars, MIT License
   - LLM-powered knowledge curation system that researches topics and generates full-length reports with citations
   - From Stanford Open Virtual Assistant Lab
   - Last updated: September 2025 (active development)

2. **R2R (SciPhi)** - 7,773 stars, MIT License  
   - Production-ready agentic RAG engine with RESTful API
   - Features hybrid search, knowledge graphs, multimodal RAG, and deep research capabilities
   - Last updated: November 2025 (active development)

### Elite Criteria Verification

| Project | Stars | License | Activity | Status |
|---------|-------|---------|----------|--------|
| STORM | 28,118+ | MIT | Active | ✅ Elite |
| R2R | 7,773+ | MIT | Active | ✅ Elite |

Both projects meet the 1000+ stars threshold, have OSI-approved MIT licenses, and show active development within the last 3 months.