### PR TITLE
Add EmbedChain - Universal memory layer for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@
 
 #### RAG Frameworks & Advanced Retrieval Tools
 
+- **[EmbedChain](https://github.com/embedchain/embedchain)** ![GitHub stars](https://img.shields.io/github/stars/embedchain/embedchain?style=social) - Universal memory layer for AI agents. Simple API to create RAG applications over any dataset with support for multiple vector stores, embedding models, and LLM providers. Apache 2.0 licensed.
 - **[LlamaIndex](https://github.com/run-llama/llama_index)** ![GitHub stars](https://img.shields.io/github/stars/run-llama/llama_index?style=social) - Full-featured RAG pipeline with advanced indexing.
 - **[R2R (SciPhi)](https://github.com/SciPhi-AI/R2R)** ![GitHub stars](https://img.shields.io/github/stars/SciPhi-AI/R2R?style=social) - Production-ready agentic RAG engine with RESTful API. Features hybrid search, knowledge graphs, multimodal RAG, and deep research capabilities. MIT licensed.
 - **[Haystack](https://github.com/deepset-ai/haystack)** ![GitHub stars](https://img.shields.io/github/stars/deepset-ai/haystack?style=social) - End-to-end NLP and RAG framework.


### PR DESCRIPTION
## Proposal: Add EmbedChain to RAG Frameworks

**EmbedChain** is a universal memory layer for AI agents that provides a simple API to create RAG applications over any dataset.

### Why EmbedChain?

- **54,033+ GitHub stars** - Elite-tier popularity
- **Apache 2.0 licensed** - OSI-approved open source
- **Active development** - Last commit: April 2026
- **Production-ready** - Battle-tested in production environments

### Key Features

- Simple API for creating RAG applications over any dataset
- Support for multiple vector stores (Chroma, Qdrant, Weaviate, etc.)
- Multiple embedding models and LLM providers
- Built for both prototyping and production deployments
- Framework-agnostic with integrations for major AI frameworks

### Links

- Repository: https://github.com/embedchain/embedchain
- License: Apache 2.0

---

This addition fits the elite-tier criteria for the awesome-opensource-ai list:
- 1000+ stars ✅
- Active development ✅
- OSI-approved license ✅
- Production-ready ✅