### PR TITLE
feat: add KubeStellar Console to EMERGING.md (MLOps/LLMOps section)

### DIFF
--- a/EMERGING.md
+++ b/EMERGING.md
@@ -101,7 +101,7 @@
 
 > Experimental observability tools, deployment patterns, and safety guardrails.
 
-*No entries yet — [submit one!](./CONTRIBUTING.md)*
+- **[KubeStellar Console](https://github.com/kubestellar/console)** ![GitHub stars](https://img.shields.io/github/stars/kubestellar/console?style=social) - AI-powered multi-cluster Kubernetes dashboard with GPU workload monitoring, AI pipeline observability, and 30+ CNCF integrations. CNCF Sandbox project. Apache-2.0 licensed.
 
 ---
 


### PR DESCRIPTION
Re-submitting to **EMERGING.md** per maintainer feedback on #373 — KubeStellar Console does not yet meet the 1000+ star elite-tier threshold.

Adds [KubeStellar Console](https://github.com/kubestellar/console) to **Section 8: MLOps / LLMOps & Production**.

- AI-powered multi-cluster Kubernetes dashboard
- GPU workload monitoring, AI pipeline observability
- 30+ CNCF project integrations
- CNCF Sandbox project (under KubeStellar)
- Apache-2.0 licensed

Happy to adjust description or placement.