### PR TITLE
Add ModelScope to Model Hubs & Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,6 +669,7 @@
 
 - **[Civitai](https://github.com/civitai/civitai)** ![GitHub stars](https://img.shields.io/github/stars/civitai/civitai?style=social) - Open-source AI model hub and community platform for sharing and discovering generative AI models, with focus on image generation models. Features model versioning, reviews, and integrated inference. Apache 2.0 licensed.
 - **[Hugging Face Hub](https://github.com/huggingface/huggingface_hub)** ![GitHub stars](https://img.shields.io/github/stars/huggingface/huggingface_hub?style=social) - Official Python client for the Hugging Face Hub. Download, upload, and manage 1M+ open-source ML models and datasets programmatically. The de facto standard for model sharing and distribution. Apache 2.0 licensed.
+- **[ModelScope](https://github.com/modelscope/modelscope)** ![GitHub stars](https://img.shields.io/github/stars/modelscope/modelscope?style=social) - Model-as-a-Service platform bringing together 700+ state-of-the-art ML models from the AI community. Covers NLP, CV, Audio, Multi-modality, and AI for Science with streamlined model inference, fine-tuning and evaluation. Apache 2.0 licensed.
 - **[OpenVINO Open Model Zoo](https://github.com/openvinotoolkit/open_model_zoo)** ![GitHub stars](https://img.shields.io/github/stars/openvinotoolkit/open_model_zoo?style=social) - Pre-trained deep learning models and demos optimized for Intel hardware. 200+ public pre-trained models for vision, speech, and NLP with benchmarking tools and accuracy metrics. Apache 2.0 licensed.
 
 #### Deployment & Orchestration


### PR DESCRIPTION
# Add ModelScope to Model Hubs & Registries

This PR adds ModelScope, a leading Model-as-a-Service platform from Alibaba, to the Model Hubs & Registries section.

## Project Details

**Name:** ModelScope  
**Repository:** https://github.com/modelscope/modelscope  
**Stars:** ~8.5k  
**License:** Apache 2.0  
**Category:** Model Hubs & Registries

## Description

ModelScope is built upon the notion of "Model-as-a-Service" (MaaS). It brings together most advanced machine learning models from the AI community, and streamlines the process of leveraging AI models in real-world applications. With 700+ publicly available models covering NLP, CV, Audio, Multi-modality, and AI for Science.

## Why Add This

- Elite-tier project with 8.5k+ stars and Apache 2.0 license
- Active development with regular updates
- Major model hub in China and globally
- Complements existing Hugging Face Hub and Civitai entries
- Provides diverse geographic coverage for model hubs

## Checklist

- [x] Project has 1000+ stars (8.5k+)
- [x] Active development (commits within last 3 months)
- [x] OSI-approved open source license (Apache 2.0)
- [x] Production-ready with well-documented API
- [x] Follows the list's format and style
