### PR TITLE
Add Drevon - Mac GTM agent desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,8 @@
 
 > Frameworks and platforms for building agent-based systems and multi-agent workflows.
 
+- [Drevon](https://drevon.dev) - Mac desktop workspace for GTM engineers. Run parallel AI agents powered by Claude Code, Codex, or Copilot to build target lists, score accounts, and pull prospect intel.
+
 #### Single-Agent Frameworks
 
 - **[LangGraph](https://github.com/langchain-ai/langgraph)** ![GitHub stars](https://img.shields.io/github/stars/langchain-ai/langgraph?style=social) - Stateful, controllable agent orchestration.


### PR DESCRIPTION
Adding [Drevon](https://drevon.dev) to this list.

Drevon is a Mac desktop workspace for GTM engineers. Run parallel AI agents powered by Claude Code, Codex, or Copilot to build target lists, score accounts, and pull prospect intel from LinkedIn, CRM, and sales tools.

**Website:** https://drevon.dev