### PR TITLE
Add vimin-core — distributed local LLM/Whisper orchestration across multiple machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@
 - **[KoboldCpp](https://github.com/LostRuins/koboldcpp)** ![GitHub stars](https://img.shields.io/github/stars/LostRuins/koboldcpp?style=social) - User-friendly llama.cpp fork focused on role-playing and creative writing.
 - **[RamaLama](https://github.com/containers/ramalama)** ![GitHub stars](https://img.shields.io/github/stars/containers/ramalama?style=social) - Container-centric tool for simplifying local AI model serving. Automatically detects GPUs, pulls optimized container images, and runs models securely in rootless containers with enterprise-grade isolation.
 - **[LiteRT-LM](https://github.com/google-ai-edge/LiteRT-LM)** ![GitHub stars](https://img.shields.io/github/stars/google-ai-edge/LiteRT-LM?style=social) - Google's production-ready inference framework for deploying LLMs on edge devices. Cross-platform support for Android, iOS, Web, Desktop, and IoT with GPU/NPU acceleration. Powers on-device GenAI in Chrome and Chromebook Plus. Apache 2.0 licensed.
+- **[vimin-core](https://github.com/pberlizov/vimin-public)** ![GitHub stars](https://img.shields.io/github/stars/pberlizov/vimin-public?style=social) — Distributed local LLM and Whisper inference orchestration across up to 10 machines. MLX on Apple Silicon, llama.cpp on any platform. Designed for air-gapped and privacy-sensitive deployments. MIT.
 
 #### High-performance Serving & API Servers
 


### PR DESCRIPTION
## What is vimin-core?

[vimin-core](https://github.com/pberlizov/vimin-public) is a Python library for orchestrating distributed local LLM and Whisper inference across a fleet of up to 10 machines — with no cloud dependency and no telemetry.

**Key features:**
- **MLX** on Apple Silicon (ANE-accelerated), **llama.cpp** on any platform, **mlx-whisper / faster-whisper** for speech
- Broadcast a prompt to all connected agents simultaneously, or run multi-step pipelines (translate → redact PII → summarize)
- Designed for **air-gapped networks**, healthcare, legal, and enterprise on-premise environments
- MIT license

Added to the **Local / On-device Inference** subsection of Inference Engines & Serving.

```bash
pip install 'vimin-core[mlx]'      # Apple Silicon
pip install 'vimin-core[llamacpp]' # Any platform
```