### PR TITLE
Add USearch and Voyager to Vector Databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,8 @@
 - **[ParadeDB](https://github.com/paradedb/paradedb)** ![GitHub stars](https://img.shields.io/github/stars/paradedb/paradedb?style=social) - Postgres-native search and analytics engine for full-text, faceted, and hybrid retrieval without moving data out of PostgreSQL.
 - **[Orama](https://github.com/oramasearch/orama)** ![GitHub stars](https://img.shields.io/github/stars/oramasearch/orama?style=social) - Lightweight search engine with full-text, vector, and hybrid search for browser, server, and edge applications.
 - **[HelixDB](https://github.com/HelixDB/helix-db)** ![GitHub stars](https://img.shields.io/github/stars/HelixDB/helix-db?style=social) - Graph-vector database for retrieval systems that need relationship traversal alongside semantic search.
+- **[USearch](https://github.com/unum-cloud/usearch)** ![GitHub stars](https://img.shields.io/github/stars/unum-cloud/usearch?style=social) - Fast single-file similarity search & clustering engine for vectors. Smaller and faster than FAISS with 20+ language bindings (C++, Python, JavaScript, Rust, Java, Go, etc.) and support for custom metrics. Apache 2.0 licensed.
+- **[Voyager](https://github.com/spotify/voyager)** ![GitHub stars](https://img.shields.io/github/stars/spotify/voyager?style=social) - Spotify's approximate nearest-neighbor search library for Python and Java. Up to 10x faster than Annoy with 4x less memory, designed for production use at billion-vector scale. Apache 2.0 licensed.
 
 #### Embedding Models
 


### PR DESCRIPTION
## Summary

This PR adds two elite-tier vector search libraries to the Vector Databases & Search Engines section:

### Added Projects

1. **[USearch](https://github.com/unum-cloud/usearch)** (4,063+ stars)
   - Fast single-file similarity search & clustering engine for vectors
   - Smaller and faster than FAISS with 20+ language bindings
   - Supports C++, Python, JavaScript, Rust, Java, Go, and more
   - Apache 2.0 licensed
   - Last updated: April 20, 2026

2. **[Voyager](https://github.com/spotify/voyager)** (1,558+ stars)
   - Spotify's approximate nearest-neighbor search library
   - Python and Java bindings with feature parity
   - Up to 10x faster than Annoy with 4x less memory
   - Battle-tested at billion-vector scale in production at Spotify
   - Apache 2.0 licensed
   - Last updated: March 1, 2026

### Elite Criteria Check

| Project | Stars | License | Active | Production-Ready |
|---------|-------|---------|--------|------------------|
| USearch | 4,063+ | Apache-2.0 | Yes (Apr 2026) | Yes |
| Voyager | 1,558+ | Apache-2.0 | Yes (Mar 2026) | Yes (Spotify prod) |

Both projects meet the elite criteria of 1000+ stars, OSI-approved licenses, active development, and production-ready status.