### PR TITLE
Add agenttrace to Emerging developer tools

### DIFF
--- a/EMERGING.md
+++ b/EMERGING.md
@@ -146,7 +146,7 @@
 
 > Fresh IDE plugins, testing frameworks, and developer productivity tools.
 
-*No entries yet — [submit one!](./CONTRIBUTING.md)*
+- **[agenttrace](https://github.com/luoyuctl/agenttrace)** ![GitHub stars](https://img.shields.io/github/stars/luoyuctl/agenttrace?style=social) - Local-first TUI for AI coding agent session observability across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, OpenCode, and more.
 
 ---
 


### PR DESCRIPTION
## Project: agenttrace

### Emerging Criteria Checklist

- [x] **Below 1000 stars** - 1 GitHub star
- [x] **Active** - latest push on May 2, 2026
- [x] **Innovation** - local-first TUI for AI coding agent session observability across multiple agent log formats
- [x] **Quality** - documented CLI, tests, releases, Homebrew formula, and published v0.3.36 release
- [x] **License** - MIT

### Target List

- [ ] Elite Tier (1000+ stars, active within 6 months, production usage)
- [x] Emerging List (active within 6 months, under 1000 stars, promising)

### Why This Belongs in Emerging

agenttrace gives developers a local terminal view for AI coding agent sessions, including cost, tokens, tool failures, latency, anomalies, health gates, and diffs across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, OpenCode, and related logs.

### Validation

- `python3 tools/validate_awesome.py --skip-remote`
- `git diff --check`

I also attempted `GITHUB_TOKEN=$(gh auth token) python3 tools/validate_awesome.py`; local Python SSL certificate verification failed against the GitHub API and caused existing entries plus the new entry to report as not returned by the API. The structural PR check should use `--skip-remote` per this repository's workflow.
