### PR TITLE
Add Uni-CLI to EMERGING > Developer Tools & Integrations

### DIFF
--- a/EMERGING.md
+++ b/EMERGING.md
@@ -148,7 +148,7 @@
 > Fresh IDE plugins, testing frameworks, and developer productivity tools.
 
 - **[agenttrace](https://github.com/luoyuctl/agenttrace)** ![GitHub stars](https://img.shields.io/github/stars/luoyuctl/agenttrace?style=social) - Local-first TUI for AI coding agent session observability across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, OpenCode, and more.
-- **[Uni-CLI](https://github.com/olo-dot-io/Uni-CLI)** ![GitHub stars](https://img.shields.io/github/stars/olo-dot-io/Uni-CLI?style=social) - Self-repairing CLI catalog exposing 237+ websites, desktop apps, and external CLIs as deterministic commands for AI agents via 920 declarative YAML adapters and structured error envelopes; ships an optional MCP server.
+- **[Uni-CLI](https://github.com/olo-dot-io/Uni-CLI)** ![GitHub stars](https://img.shields.io/github/stars/olo-dot-io/Uni-CLI?style=social) - Self-repairing CLI catalog exposing 238 sites and 1,458 commands across web, desktop apps, Electron apps, and bridge CLIs as deterministic commands for AI agents (counts from the repo's live README STATS counters). Declarative YAML adapters with structured error envelopes; ships an optional MCP server.
 
 ---
 

--- a/EMERGING.md
+++ b/EMERGING.md
@@ -148,7 +148,7 @@
 > Fresh IDE plugins, testing frameworks, and developer productivity tools.
 
 - **[agenttrace](https://github.com/luoyuctl/agenttrace)** ![GitHub stars](https://img.shields.io/github/stars/luoyuctl/agenttrace?style=social) - Local-first TUI for AI coding agent session observability across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, OpenCode, and more.
-- **[Uni-CLI](https://github.com/olo-dot-io/Uni-CLI)** ![GitHub stars](https://img.shields.io/github/stars/olo-dot-io/Uni-CLI?style=social) - Self-repairing CLI catalog exposing 238 sites and 1,458 commands across web, desktop apps, Electron apps, and bridge CLIs as deterministic commands for AI agents (counts from the repo's live README STATS counters). Declarative YAML adapters with structured error envelopes; ships an optional MCP server.
+- **[Uni-CLI](https://github.com/olo-dot-io/Uni-CLI)** ![GitHub stars](https://img.shields.io/github/stars/olo-dot-io/Uni-CLI?style=social) - Self-repairing CLI catalog that exposes web, desktop apps, Electron apps, and bridge CLIs as deterministic commands for AI agents. Declarative YAML adapters with structured error envelopes; ships an optional MCP server. Live catalog size tracked in the repo's README.
 
 ---
 

--- a/EMERGING.md
+++ b/EMERGING.md
@@ -148,6 +148,7 @@
 > Fresh IDE plugins, testing frameworks, and developer productivity tools.
 
 - **[agenttrace](https://github.com/luoyuctl/agenttrace)** ![GitHub stars](https://img.shields.io/github/stars/luoyuctl/agenttrace?style=social) - Local-first TUI for AI coding agent session observability across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, OpenCode, and more.
+- **[Uni-CLI](https://github.com/olo-dot-io/Uni-CLI)** ![GitHub stars](https://img.shields.io/github/stars/olo-dot-io/Uni-CLI?style=social) - Self-repairing CLI catalog exposing 237+ websites, desktop apps, and external CLIs as deterministic commands for AI agents via 920 declarative YAML adapters and structured error envelopes; ships an optional MCP server.
 
 ---
 


### PR DESCRIPTION
## Project: Uni-CLI

### Emerging Criteria Checklist

- [x] **Below 1000 stars** — currently ~5★ (repository moved from `ZenAlexa` to `olo-dot-io` org recently)
- [x] **Active** in last 6 months — created 2026-04-04, latest release v0.218.0 on 2026-05-05 (today), released ~50 versions in 30 days
- [x] **Innovation** — self-repairing CLI catalog: structured error envelopes (`adapter_path`, `step`, `suggestion`, `retryable`, `alternatives`) so AI agents edit failing 20-line YAML adapters at runtime and retry without a maintainer in the loop
- [x] **Quality** — full TypeScript strict, `npm run verify` (typecheck + lint + tests), 170 test files, dedicated docs site, 0.5%+ coverage of major sites
- [x] **License** — Apache-2.0 (OSI-approved)

### Target List
- [ ] Elite Tier (1000+ stars, active within 6 months, production usage)
- [x] Emerging List (active within 6 months, under 1000 stars, promising)

### Why This Belongs in Emerging

Uni-CLI sits at the agent-infrastructure layer that the open-source landscape is converging on (cf. mcp2cli, Apideck CLI, OnlyCLI — all CLI-for-agents projects). The unique angle is **decidable adapters**: every command is a 20-line YAML pipeline (Rice's restriction → no Turing-complete logic), and every error response carries enough metadata for an AI agent to diagnose and repair the failing adapter.

Numbers (v0.218.0):
- **237 sites** (web, desktop, Electron apps)
- **3,319 commands**
- **920 YAML + 216 TS adapters** (1136 total)
- **170 test files**
- **Median ~80 tokens per call** (vs typical MCP equivalents in the multiples)

Optional MCP server (stdio + Streamable HTTP) is available for environments that prefer MCP. The CLI is the primary surface — direct execution avoids MCP context bloat.

### Category
**🧪 13. Developer Tools & Integrations** — alongside `agenttrace` (CLI observability for AI coding agents). Uni-CLI is in the same niche: a CLI tool that AI agents call to do work.

### Section signals comparable to existing entries
The current section's lead entry (agenttrace) is similarly emerging — focused, agent-targeted CLI tooling with active development and basic docs. Uni-CLI matches that bar and ships richer adapter coverage.

### Format
- `- **[Project Name](url)** ![GitHub stars](shield) - description.` per CONTRIBUTING.
- Factual one-line description; no marketing language ("revolutionary", "next-gen").
- Inserted at end of section 13 alphabetically (after `agenttrace`).
- License OSI-approved; running `python3 tools/validate_awesome.py --skip-remote` should pass (single-line addition, no structural changes).