### PR TITLE
Add Awesome AI Startups to Curated Resource Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1314,6 +1314,7 @@
 
 - **[Awesome Machine Learning](https://github.com/josephmisiti/awesome-machine-learning)** ![GitHub stars](https://img.shields.io/github/stars/josephmisiti/awesome-machine-learning?style=social) - The definitive curated list of machine learning frameworks, libraries and software organized by language. Covers Python, C++, Java, JavaScript, and more with comprehensive coverage of the ML ecosystem. CC0-1.0 licensed.
 - **[Andrej Karpathy Skills](https://github.com/forrestchang/andrej-karpathy-skills)** ![GitHub stars](https://img.shields.io/github/stars/forrestchang/andrej-karpathy-skills?style=social) - A single CLAUDE.md file to improve Claude Code behavior, derived from Andrej Karpathy's observations on LLM coding pitfalls. Principles: Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution. MIT licensed.
+- **[Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups)** ![GitHub stars](https://img.shields.io/github/stars/nowork-studio/awesome-ai-startups?style=social) - A curated list of bootstrapped, pre-seed, and angel-funded AI products built by independent founders. Organized by category (marketing, coding, content, design, productivity, and more) for discovering indie AI tools. CC0-1.0 licensed.
 
 ---
 


### PR DESCRIPTION
Adds one entry to the **Curated Resource Lists** subsection (under §14 Resources & Learning):

- **[Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups)** — A curated list of bootstrapped, pre-seed, and angel-funded AI products built by independent founders. Organized by category (marketing, coding, content, design, productivity, and more) for discovering indie AI tools. CC0-1.0 licensed.

### Checklist
- Format matches existing entries in the section (bold title, GitHub stars badge, description, license note)
- License: CC0-1.0 (OSI-recognized public-domain dedication)
- Actively maintained
- High-quality, well-documented curated list