### PR TITLE
feat: add llm-prices — CLI and MCP server for LLM API pricing comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -1173,6 +1173,7 @@ Open-source artificial intelligence models, libraries, infrastructure, and devel
 
 #### CLI Tools & API Clients
 
+- [llm-prices](https://github.com/benbencodes/llm-prices) - Zero-dependency CLI and MCP server for comparing LLM API pricing across 22 providers (OpenAI, Anthropic, Google, xAI, Mistral, and more). Calculate exact API costs, find cheapest models for any workload, 130 models, offline-first with no API key required. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/benbencodes/llm-prices?style=social)
 - [Ruler](https://github.com/intellectronica/ruler) - Central AI agent rule registry. Manages and distributes rules for AI coding agents across projects. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/intellectronica/ruler?style=social)
 - [PR-Agent (Qodo)](https://github.com/qodo-ai/pr-agent) - AI-powered code review agent for GitHub, GitLab, Bitbucket, and Azure DevOps. Automated PR analysis, improvement suggestions, and multi-platform deployment via CLI, GitHub Actions, or webhooks. AGPL-3.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/qodo-ai/pr-agent?style=social)
 - [LLM (Simon Willison)](https://github.com/simonw/llm) - CLI tool and Python library for interacting with dozens of LLMs via remote APIs or locally. Extensible plugin ecosystem, SQLite logging. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/simonw/llm?style=social)


### PR DESCRIPTION
## Summary

Adds [llm-prices](https://github.com/benbencodes/llm-prices) to the **CLI Tools & API Clients** section.

**What it does:** Zero-dependency Python CLI and MCP server for comparing LLM API pricing across 22 providers. Developers use it to:
- Find the cheapest model for a given token budget
- Calculate exact API costs before committing to a provider
- Compare pricing across OpenAI, Anthropic, Google, xAI, Mistral, Groq, DeepSeek, and 15 more

**Key facts:**
- 130 models across 22 providers (data updated regularly)
- Zero dependencies — works offline, no API key required
- MCP server for AI assistant integration (Claude Desktop, Cursor, etc.)
- MIT licensed
- Install: `pip install llm-prices`

**Example:**
```
$ llm-prices list --top 5
$ llm-prices calc --model gpt-4o --input 1000000 --output 200000
$ llm-prices compare --models gpt-4o,claude-sonnet-4-6,gemini-2.5-flash
```