### PR TITLE
Add ARC-Neuron LLMBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,6 +753,8 @@ Open-source artificial intelligence models, libraries, infrastructure, and devel
 
 ## 8. MLOps / LLMOps & Production
 
+- [ARC-Neuron LLMBuilder](https://github.com/GareBear99/ARC-Neuron-LLMBuilder) - Local-first AI model lifecycle framework for benchmark receipts, candidate/incumbent model promotion, archive-ready lineage, and governed small-model improvement. ![GitHub stars](https://img.shields.io/github/stars/GareBear99/ARC-Neuron-LLMBuilder?style=social)
+
 > Tooling for tracking, deploying, monitoring, and operating AI systems in production.
 
 #### Experiment Tracking & Versioning


### PR DESCRIPTION
Adds ARC-Neuron LLMBuilder as a local-first AI model lifecycle / governance tool.

ARC-Neuron focuses on deterministic small-model promotion, benchmark receipts, candidate/incumbent comparison, archive-ready lineage, and evidence-first local AI improvement.

Main repo:
https://github.com/GareBear99/ARC-Neuron-LLMBuilder

Protected v1.0.0 release baseline:
https://github.com/GareBear99/arc-neuron-llmbuilder-v1.0.0

Suggested placement:
- AI Developer Tools
- Local AI Tools
- LLMOps / Model Lifecycle
- Trustworthy AI / Provenance
- Reproducible AI
- Small Language Model Governance
