### PR TITLE
Add Dakera: open-source self-hosted MCP agent memory server

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ Open-source artificial intelligence models, libraries, infrastructure, and devel
 - [Letta (ex-MemGPT)](https://github.com/letta-ai/letta) - Platform for building stateful agents with advanced memory that learn and self-improve over time. ![GitHub stars](https://img.shields.io/github/stars/letta-ai/letta?style=social)
 - [Mem0](https://github.com/mem0ai/mem0) - Universal memory layer for AI agents. Persistent, multi-session memory across models and environments. ![GitHub stars](https://img.shields.io/github/stars/mem0ai/mem0?style=social)
 - [Hindsight](https://github.com/vectorize-io/hindsight) - State-of-the-art long-term memory for AI agents by Vectorize. Fully self-hosted, MIT-licensed, with integrations for LangChain, CrewAI, LlamaIndex, Vercel AI SDK, and more. ![GitHub stars](https://img.shields.io/github/stars/vectorize-io/hindsight?style=social)
+- [Dakera](https://github.com/dakera-ai/dakera-mcp) - Self-hosted open-source MCP agent memory server. HNSW vector search, RocksDB persistence, decay-weighted recall, and cross-agent knowledge sharing. Python, JavaScript, Rust, Go SDKs. ![GitHub stars](https://img.shields.io/github/stars/dakera-ai/dakera-mcp?style=social)
 
 ---
 


### PR DESCRIPTION
## What

Adds [Dakera](https://github.com/dakera-ai/dakera-mcp) to the **Agent Memory & State** section under *4. Agentic AI & Multi-Agent Systems*.

## Why

Dakera is an open-source, self-hosted MCP (Model Context Protocol) agent memory server. It provides HNSW vector search, RocksDB persistence, decay-weighted recall, and cross-agent knowledge sharing — with official SDKs for Python, JavaScript, Rust, and Go. It fits squarely in the Agent Memory & State category alongside Letta and Mem0.

## Checklist

- [x] No benchmark scores or percentage numbers in the description
- [x] Entry follows existing format (dash, link, description, stars badge)
- [x] Added in alphabetical position within the section
- [x] Verified no existing Dakera entry in README