### PR TITLE
Add Page Agent under Single-Agent Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Good entries should have a clear reason to exist. They should help people build,
 - [Flue](https://github.com/withastro/flue) - Programmable TypeScript harness and sandbox agent framework for building autonomous workflows and agents. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/withastro/flue?style=social)
 - [Agent-Native](https://github.com/BuilderIO/agent-native) - TypeScript-first framework for building agent-first applications featuring shared database state, real-time multiplayer editing, and action-driven tools. ISC licensed. ![GitHub stars](https://img.shields.io/github/stars/BuilderIO/agent-native?style=social)
 - [rlm](https://github.com/alexzhang13/rlm) - General plug-and-play inference library for Recursive Language Models (RLMs) that programmatically execute sub-LM calls inside isolated code sandboxes. ![GitHub stars](https://img.shields.io/github/stars/alexzhang13/rlm?style=social)
+- [Page Agent](https://github.com/alibaba/page-agent) - JavaScript-native, in-page GUI agent framework for controlling web interfaces with natural language without screenshots or external browser automation. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/alibaba/page-agent?style=social)
 
 #### Multi-Agent Orchestration
 


### PR DESCRIPTION
## Project

- Name: Page Agent
- URL: https://github.com/alibaba/page-agent
- Category: Single-Agent Frameworks

## Why it belongs

It is a JavaScript-native in-page GUI agent framework to control web interfaces using natural language without screenshots or external browser automation.

## Quality signals

- License: MIT License
- Maintenance status: Active
- Documentation/examples: Rich documentation and interactive demo
- Distinction from similar projects: Runs natively in-page using text-based DOM manipulation instead of screenshots or multi-modal LLMs.