### PR TITLE
Add qq-ai-bot to local AI chat UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1134,6 +1134,7 @@ Good entries should have a clear reason to exist. They should help people build,
 #### Local AI Chat UIs & Personal Assistants
 
 - [OpenClaw](https://github.com/openclaw/openclaw) - Local-first personal AI assistant with multi-channel integrations and full agentic task execution. ![GitHub stars](https://img.shields.io/github/stars/openclaw/openclaw?style=social)
+- [happysnaker/qq-ai-bot](https://github.com/happysnaker/qq-ai-bot) - Self-hosted QQ ↔ AI bridge for OneBot 11 / NapCat / LLOneBot that connects ACP-compatible local agents with session persistence and progress streaming. ![GitHub stars](https://img.shields.io/github/stars/happysnaker/qq-ai-bot?style=social)
 - [Open WebUI](https://github.com/open-webui/open-webui) - Most popular self-hosted ChatGPT-style interface. ![GitHub stars](https://img.shields.io/github/stars/open-webui/open-webui?style=social)
 - [text-generation-webui](https://github.com/oobabooga/text-generation-webui) - Web UI for running local LLMs with multiple backends, extensions, and model formats. ![GitHub stars](https://img.shields.io/github/stars/oobabooga/text-generation-webui?style=social)
 - [LobeChat](https://github.com/lobehub/lobe-chat) - Sleek modern chat UI. ![GitHub stars](https://img.shields.io/github/stars/lobehub/lobe-chat?style=social)


### PR DESCRIPTION
## Project

- Name: qq-ai-bot
- URL: https://github.com/happysnaker/qq-ai-bot
- Category: 12. User Interfaces & Self-hosted Platforms → Local AI Chat UIs & Personal Assistants

## Why it belongs

qq-ai-bot helps people run a self-hosted AI assistant over QQ by bridging OneBot 11 / NapCat / LLOneBot with ACP-compatible local agents. It gives builders a messaging-first interface with session persistence, progress streaming, and Docker-based deployment.

## Quality signals

- License: MIT
- Maintenance status: Active, with current docs, CI, release, and roadmap
- Documentation/examples: README, architecture docs, Docker demo stack, and integration guides
- Distinction from similar projects: unlike browser-first chat UIs, this project focuses on QQ as the interaction surface and on bridging ACP-compatible local agents into an existing messaging workflow
