### PR TITLE
Add Off Grid AI Desktop to Desktop & Mobile AI Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1246,6 +1246,7 @@ Good entries should have a clear reason to exist. They should help people build,
 - [T3 Code](https://github.com/pingdotgg/t3code) - Minimal web GUI and desktop app for interacting with coding agents like Codex, Claude Code, Cursor, and OpenCode. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/pingdotgg/t3code?style=social)
 - [OpenWork](https://github.com/different-ai/openwork) - Open-source desktop app for sharing AI workflows, skills, and MCP capabilities across agents. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/different-ai/openwork?style=social)
 - [ego lite](https://github.com/citrolabs/ego-lite) - Desktop browser designed for running web automation tasks and AI agents in parallel within isolated workspaces. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/citrolabs/ego-lite?style=social)
+- [Off Grid AI Desktop](https://github.com/off-grid-ai/OGAD) - Local-first macOS AI app that runs LLM chat, image generation, voice transcription, and personal memory/RAG fully on-device via llama.cpp - nothing leaves the machine. AGPL-3.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/off-grid-ai/OGAD?style=social)
 
 #### Agent & Voice Infrastructure
 


### PR DESCRIPTION
## What
Adds [Off Grid AI Desktop](https://github.com/off-grid-ai/OGAD) to **Desktop & Mobile AI Apps**, alongside Jan, Cherry Studio, and Chatbox.

## About
Open-source (AGPL-3.0) macOS app that runs a full local AI suite on your Mac - nothing leaves the device.
- Local LLM chat via llama.cpp
- On-device image generation and whisper voice transcription
- Personal memory / RAG search over your own data
- Encrypted vault, clipboard manager, MCP connectors
- No account, no telemetry, no cloud

Disclosure: I'm involved with the project.