### PR TITLE
Add PieKBS to RAG Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,7 @@ Good entries should have a clear reason to exist. They should help people build,
 - [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) - Self-hosted AI data assistant for private knowledge, database-aware conversations, and data-heavy RAG workflows. ![GitHub stars](https://img.shields.io/github/stars/eosphoros-ai/DB-GPT?style=social)
 - [localGPT](https://github.com/PromtEngineer/localGPT) - Local document-chat project for private, on-device Q&A over files without sending data to external APIs. ![GitHub stars](https://img.shields.io/github/stars/PromtEngineer/localGPT?style=social)
 - [SurfSense](https://github.com/MODSetter/SurfSense) - Privacy-focused NotebookLM-style workspace for teams to search, organize, and query knowledge with self-hosted RAG. ![GitHub stars](https://img.shields.io/github/stars/MODSetter/SurfSense?style=social)
+- [PieKBS](https://github.com/pieteams/piekbs) - Local-first knowledge search engine for agents with FTS5 full-text search and graph-based document expansion via citation/support/wiki links. Pure Go, no embedding required. ![GitHub stars](https://img.shields.io/github/stars/pieteams/piekbs?style=social)
 - [Morphik](https://github.com/morphik-org/morphik-core) - Open-source multimodal RAG framework for building AI apps over private knowledge. Handles text, images, and documents with built-in embedding generation and vector search. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/morphik-org/morphik-core?style=social)
 
 #### Knowledge Graphs for RAG


### PR DESCRIPTION
Hi, thanks for maintaining this list - it's a great resource.

I'd like to add **PieKBS** to the RAG Frameworks & Advanced Retrieval Tools section.

- Repo: https://github.com/pieteams/piekbs
- License: MIT
- Docs: https://pieteams.github.io/piekbs/

PieKBS is a local-first knowledge search engine for agents. It distills raw documents into a structured Markdown wiki and exposes MCP tools for search and deep-reading. Key features:

- **FTS5 full-text search** with BM25 scoring (no embedding required)
- **Graph-based document expansion** via citation/support/wiki/related_to links
- **Multi-hop tag expansion** for discovering related documents through shared keywords
- **MCP protocol support** for seamless integration with AI agents
- **Pure Go binary** with no external dependencies

Happy to adjust the wording or placement if needed.