### PR TITLE
Add ContinueWith — AI-native continuation widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Curated open-source artificial intelligence models, libraries, infrastructure, and developer tools.
 
+- [ContinueWith](https://continuewith.ai) - Let visitors continue any website page inside ChatGPT, Claude, Gemini, Grok, Perplexity, Mistral, and other AI assistants in one click.
+
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 </div>


### PR DESCRIPTION
Adds [ContinueWith](https://continuewith.ai) to the AI directories list.

ContinueWith lets visitors hand off any website page to their preferred AI assistant in one click.

Submitted via ContinueWith Distribution Loop.