### PR TITLE
feat: add JMT x402 Agent Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,7 @@ Good entries should have a clear reason to exist. They should help people build,
 - [SurfSense](https://github.com/MODSetter/SurfSense) - Privacy-focused NotebookLM-style workspace for teams to search, organize, and query knowledge with self-hosted RAG. ![GitHub stars](https://img.shields.io/github/stars/MODSetter/SurfSense?style=social)
 - [Morphik](https://github.com/morphik-org/morphik-core) - Open-source multimodal RAG framework for building AI apps over private knowledge. Handles text, images, and documents with built-in embedding generation and vector search. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/morphik-org/morphik-core?style=social)
 - [Beever Atlas](https://github.com/Beever-AI/beever-atlas) - Open-source LLM knowledge base combining Neo4j knowledge graph with Weaviate vector DB for graph-based RAG. Native MCP server, team chat ingestion (Slack, Discord, Teams, Telegram), and BYO LLM via LiteLLM. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/Beever-AI/beever-atlas?style=social)
+- [JMT x402 Agent Tools](https://jmt-x402-proxy.jmthomasofficial.workers.dev) — 25 paid x402 endpoints on Base mainnet: web search, AI analysis, crypto/stock data, SEC filings, company intel, news, sentiment, macro dashboard. $0.001-$0.15/call USDC. Local LLM-powered.
 
 #### Knowledge Graphs for RAG
 


### PR DESCRIPTION
## What\n\nAdds JMT x402 Agent Tools — 25 paid x402 endpoints on Base mainnet.\n\n## Service Details\n\n- **URL:** https://jmt-x402-proxy.jmthomasofficial.workers.dev\n- **Network:** Base mainnet (eip155:8453)\n- **Endpoints:** 25 paid endpoints covering web search, AI analysis, crypto/stock data, SEC filings, company intel, news, sentiment, macro dashboard\n- **Price range:** $0.001-$0.15 per call\n- **Currency:** USDC on Base\n- **Wallet:** 0x624FaF18C78456C8Da5bf156Cd77c1A2033F21c5\n- **Discovery:** /.well-known/x402, /openapi.json, /llms.txt\n\n## Verification\n\n- [x] curl -I https://jmt-x402-proxy.jmthomasofficial.workers.dev/api/search returns 402\n- [x] /.well-known/x402 returns valid x402 discovery document\n- [x] /openapi.json has x-payment-info on all paid operations