### PR TITLE
Add AI Language Partner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1180,6 +1180,7 @@ Good entries should have a clear reason to exist. They should help people build,
 
 #### Desktop & Mobile AI Apps
 
+- [AI Language Partner](https://github.com/duct-tape2/ai-language-partner) - Local-first Expo and FastAPI Japanese practice app for Korean speakers that uses Whisper-compatible STT, local TTS, and embedding-based dialogue matching without a runtime LLM. ![GitHub stars](https://img.shields.io/github/stars/duct-tape2/ai-language-partner?style=social)
 - [Jan](https://github.com/janhq/jan) - Local-first AI app framework. ![GitHub stars](https://img.shields.io/github/stars/janhq/jan?style=social)
 - [Cherry Studio](https://github.com/CherryHQ/cherry-studio) - AI productivity studio with smart chat, autonomous agents, and 300+ assistants. Unified access to frontier LLMs. AGPL-3.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/CherryHQ/cherry-studio?style=social)
 - [DeepChat](https://github.com/ThinkInAIXYZ/deepchat) - A smart assistant that connects powerful AI to your personal world. Built-in MCP and ACP support, multiple search engines, privacy-focused with local data storage. Apache-2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/ThinkInAIXYZ/deepchat?style=social)


### PR DESCRIPTION
## Project

- Name: AI Language Partner
- URL: https://github.com/duct-tape2/ai-language-partner
- Category: User Interfaces & Self-hosted Platforms / Desktop & Mobile AI Apps

## Why it belongs

It is a maintained reference app for combining an Expo client with FastAPI, local Whisper-compatible speech recognition, local TTS, and embedding-based dialogue matching without a runtime LLM or paid AI API dependency.

## Quality signals

- License: MIT
- Maintenance status: Active
- Documentation/examples: README, setup runbooks, tests, and a hosted web demo
- Distinction from similar projects: Korean-speaker Japanese learning focus with a local-first speech pipeline and deterministic dialogue bank

Validation: python3 tools/validate_awesome.py --skip-remote completed with 0 errors; it reported one pre-existing duplicate-entry warning unrelated to this change.