### PR TITLE
Add Alex - open-source novel-writing engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1056,6 +1056,10 @@ Good entries should have a clear reason to exist. They should help people build,
 - [nnU-Net](https://github.com/MIC-DKFZ/nnUNet) - Self-configuring deep learning method for medical image segmentation. Automatically adapts to any dataset without manual parameter tuning. Widely adopted as the standard baseline for biomedical segmentation challenges. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/MIC-DKFZ/nnUNet?style=social)
 - [OpenMed](https://github.com/maziyarpanahi/openmed) - Local-first healthcare AI framework and application for clinical text de-identification, entity extraction, and on-device specialized model serving. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/maziyarpanahi/openmed?style=social)
 
+#### Creative Writing & Narrative AI
+
+- [Alex](https://github.com/Alex663028/Alex-Novel-Platform) - Open-source desktop novel-writing engine and AI story scaffold with Tauri, FastAPI, SQLite, and plot-generation workflows. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/Alex663028/Alex-Novel-Platform?style=social)
+
 #### Game AI & Simulations
 
 - [Unity ML-Agents](https://github.com/Unity-Technologies/ml-agents) - Toolkit for training intelligent agents in games and simulations using deep reinforcement learning. Enables NPC behavior control, automated testing, and game design evaluation. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/Unity-Technologies/ml-agents?style=social)


### PR DESCRIPTION
## Summary
- Adds **Alex** under **11. Specialized Domains > Creative Writing & Narrative AI**.
- Project: https://github.com/Alex663028/Alex-Novel-Platform

## Checklist
- [x] Entry added in an appropriate section
- [x] Description is concise and non-promotional
- [x] Repository is public and accessible