### PR TITLE
Add Markstream streaming Markdown renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1289,6 +1289,7 @@ Good entries should have a clear reason to exist. They should help people build,
 
 - [Assistant UI](https://github.com/assistant-ui/assistant-ui) - React/TypeScript library for building production-grade AI chat interfaces. Drop-in components for streaming messages, tool calls, and multi-modal inputs. ![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui?style=social)
 - [Deep Chat](https://github.com/OvidijusParsiunas/deep-chat) - Fully customizable AI chatbot component for your website. Supports OpenAI, direct API services, and custom endpoints. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/OvidijusParsiunas/deep-chat?style=social)
+- [Markstream](https://github.com/Simon-He95/markstream-vue) - Multi-framework streaming Markdown renderer for AI chat interfaces, with incomplete Markdown handling, Mermaid, KaTeX, Shiki/Monaco code blocks, SSR, and packages for Vue, React, Svelte, and Angular. ![GitHub stars](https://img.shields.io/github/stars/Simon-He95/markstream-vue?style=social)
 - [CopilotKit](https://github.com/CopilotKit/CopilotKit) - Best-in-class SDK for building full-stack agentic applications, Generative UI, and chat applications. Creators of the AG-UI Protocol adopted by Google, LangChain, AWS, and Microsoft. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/CopilotKit/CopilotKit?style=social)
 
 #### CLI Tools & API Clients


### PR DESCRIPTION
## Project

- Name: Markstream
- URL: https://github.com/Simon-He95/markstream-vue
- Category: UI Components & Chat Libraries

## Why it belongs

Markstream helps developers render incomplete Markdown while LLM responses are still streaming. It provides framework packages for Vue/Nuxt, React/Next.js, Svelte, Angular, and Vue 2, plus framework-independent parser and core packages.

## Quality signals

- License: MIT
- Maintenance status: Actively maintained with current releases and ongoing development
- Documentation/examples: https://markstream.simonhe.me/frameworks and https://markstream-vue.simonhe.me/
- Distinction from similar projects: Handles incomplete Markdown states and progressively updates Mermaid, KaTeX, and code blocks across multiple frontend frameworks, with SSR and long-response support.

Disclosure: I am the project maintainer.