### PR TITLE
Add Markstream to UI components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1290,6 +1290,7 @@ Good entries should have a clear reason to exist. They should help people build,
 
 - [Assistant UI](https://github.com/assistant-ui/assistant-ui) - React/TypeScript library for building production-grade AI chat interfaces. Drop-in components for streaming messages, tool calls, and multi-modal inputs. ![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui?style=social)
 - [Deep Chat](https://github.com/OvidijusParsiunas/deep-chat) - Fully customizable AI chatbot component for your website. Supports OpenAI, direct API services, and custom endpoints. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/OvidijusParsiunas/deep-chat?style=social)
+- [Markstream](https://github.com/Simon-He95/markstream-vue) - Multi-framework streaming Markdown renderer for AI chat interfaces, with packages for Vue, React, Svelte, Angular, and Vue 2 plus Mermaid, KaTeX, Shiki, Monaco, and safe HTML. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/Simon-He95/markstream-vue?style=social)
 - [CopilotKit](https://github.com/CopilotKit/CopilotKit) - Best-in-class SDK for building full-stack agentic applications, Generative UI, and chat applications. Creators of the AG-UI Protocol adopted by Google, LangChain, AWS, and Microsoft. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/CopilotKit/CopilotKit?style=social)
 
 #### CLI Tools & API Clients


### PR DESCRIPTION
## Project

- Name: Markstream
- URL: https://github.com/Simon-He95/markstream-vue
- Category: Developer Tools & Integrations → UI Components & Chat Libraries

## Why it belongs

Markstream helps developers render token-by-token Markdown in AI chat applications without waiting for a complete response. It provides maintained packages for Vue, React, Svelte, Angular, and Vue 2, with common AI-output features including code highlighting, diagrams, math, editable code blocks, and safe HTML.

## Quality signals

- License: MIT
- Maintenance status: Actively maintained, with recent releases and repository activity
- Documentation/examples: https://markstream.simonhe.me/
- Distinction from similar projects: It is a focused streaming Markdown rendering layer rather than a complete chat UI, and supports five frontend framework targets from one project.
