### PR TITLE
Add fractal to Multi-Agent Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ Good entries should have a clear reason to exist. They should help people build,
 - [Council of High Intelligence](https://github.com/0xNyk/council-of-high-intelligence) - Multi-agent deliberation framework that routes specialized personas across different LLM providers to debate topics and reach consensus. ![GitHub stars](https://img.shields.io/github/stars/0xNyk/council-of-high-intelligence?style=social)
 - [Gas Town](https://github.com/gastownhall/gastown) - Multi-agent workspace manager and orchestration system for Claude Code and other coding agents with persistent work tracking, mailboxes, and automated merge queues. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/gastownhall/gastown?style=social)
 - [Open Deep Research](https://github.com/langchain-ai/open_deep_research) - Open-source deep research assistant that orchestrates language models and search tools to run multi-step web research and compile reports. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/langchain-ai/open_deep_research?style=social)
+- [fractal](https://github.com/plasma-ai/fractal) - Hierarchical coding-agent orchestrator with recursive delegation, per-node Git worktrees, configurable limits, persistent SQLite state, and live terminal monitoring and steering. ![GitHub stars](https://img.shields.io/github/stars/plasma-ai/fractal?style=social)
 
 #### Agent Protocols & Standards
 

--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ Good entries should have a clear reason to exist. They should help people build,
 - [Maka](https://github.com/apache/maka) - Apache-incubating local-first AI-agent workspace with durable append-only agent execution history, licensed under Apache-2.0. ![GitHub stars](https://img.shields.io/github/stars/apache/maka?style=social)
 - [Ruflo](https://github.com/ruvnet/ruflo) - Multi-agent orchestration and meta-harness for coordinating agent swarms with shared memory, licensed under the MIT license. ![GitHub stars](https://img.shields.io/github/stars/ruvnet/ruflo?style=social)
 - [munder-difflin](https://github.com/chaitanyagiri/munder-difflin) - MIT-licensed desktop multi-agent workspace and harness for coordinating local coding agents across multiple LLM backends. ![GitHub stars](https://img.shields.io/github/stars/chaitanyagiri/munder-difflin?style=social)
+- [fractal](https://github.com/plasma-ai/fractal) - Hierarchical coding-agent orchestrator with recursive delegation, per-node Git worktrees, configurable limits, persistent SQLite state, and live terminal monitoring and steering. ![GitHub stars](https://img.shields.io/github/stars/plasma-ai/fractal?style=social)
 
 #### Agent Protocols & Standards
 


### PR DESCRIPTION
## Project

- Name: fractal
- URL: https://github.com/plasma-ai/fractal
- Category: Agentic AI & Multi-Agent Systems → Multi-Agent Orchestration

## Why it belongs

fractal is an Apache-2.0 runtime for hierarchical coding-agent loops. Nodes delegate separable work to children, use separate Git worktrees, persist run state in SQLite, and expose configurable limits plus live terminal controls.

It gives builders a concrete reference for recursive delegation and operator-controlled coding-agent workflows.

## Quality signals

- License: Apache-2.0
- Maintenance status: Active; last pushed July 22, 2026
- Documentation/examples: The README includes PyPI installation and initial usage, with additional documentation at https://docs.plasma.ai/fractal
- Distinction from similar projects: Recursive tree growth, per-node Git worktrees, persistent state, bounded loops, and live operator steering are combined in one runtime

## Validation

- `python3 tools/validate_awesome.py --skip-remote`
- `git diff --check`
- Confirmed the repository URL returns HTTP 200
- Duplicate README, history, issue, and pull-request searches found no existing fractal submission

Disclosure: I am affiliated with Plasma AI, which maintains fractal.
