### PR TITLE
Add Ouroboros to Single-Agent Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ Good entries should have a clear reason to exist. They should help people build,
 - [Page Agent](https://github.com/alibaba/page-agent) - JavaScript-native, in-page GUI agent framework for controlling web interfaces with natural language without screenshots or external browser automation. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/alibaba/page-agent?style=social)
 - [Computer (Cloudflare)](https://github.com/cloudflare/computer) - Virtual filesystem inside a Durable Object providing sandboxed execution environments for AI agents. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/cloudflare/computer?style=social)
 - [Embabel](https://github.com/embabel/embabel-agent) - Agent framework for the JVM written in Kotlin with dynamic goal-oriented planning and Spring Boot integration. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/embabel/embabel-agent?style=social)
+- [Ouroboros](https://github.com/razzant/ouroboros) - Self-hosted general-purpose agent with durable identity and memory, specialist subagent coordination, and reviewed changes to its own implementation. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/razzant/ouroboros?style=social)
 
 #### Multi-Agent Orchestration
 


### PR DESCRIPTION
## Project

- Name: Ouroboros
- URL: https://github.com/razzant/ouroboros
- Category: Frameworks and Orchestration / Single-Agent Frameworks

## Why it belongs

Ouroboros is a self-hosted general-purpose agent with durable identity and memory, specialist subagent coordination, and reviewed changes to its own implementation. It gives builders a complete inspectable runtime with desktop and headless interfaces over the same agent loop.

## Quality signals

- License: MIT
- Maintenance status: Active, latest stable release v6.87.5
- Documentation/examples: Repository README, architecture documentation, install guide, and public benchmark evidence
- Distinction from similar projects: Persistent runtime state and a reviewed self-modification path are built into the same runtime that handles ordinary tasks

I maintain the project. Thanks for considering it.
