### PR TITLE
Add PlenumView from benchmark listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,6 +945,7 @@ Good entries should have a clear reason to exist. They should help people build,
 - [AgentBench (THUDM)](https://github.com/THUDM/AgentBench) - Comprehensive benchmark to evaluate LLMs as agents across 8 diverse environments including household, web shopping, OS interaction, and database tasks. ICLR 2024. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/THUDM/AgentBench?style=social)
 - [MLE-bench (OpenAI)](https://github.com/openai/mle-bench) - Benchmark for measuring how well AI agents perform at machine learning engineering. Evaluates agents on 75 Kaggle competitions covering diverse ML tasks. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/openai/mle-bench?style=social)
 - [PinchBench](https://github.com/pinchbench/skill) - Benchmarking system for evaluating LLM models as OpenClaw coding agents. Built with Rust by the kilo.ai team. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/pinchbench/skill?style=social)
+- [PlenumView](https://github.com/evan-khanna-dev/plenumview) - Open-source tool that sends one prompt to multiple LLMs via OpenRouter and shows their responses side by side, so you can see how models actually diverge instead of trusting a single answer. ![GitHub stars](https://img.shields.io/github/stars/evan-khanna-dev/plenumview?style=social)
 
 #### Evaluation Frameworks
 


### PR DESCRIPTION
## Project

- Name: PlenumView
- URL: https://github.com/evan-khanna-dev/plenumview
- Category: Evaluation, Benchmarks & Datasets Benchmark Suite

## Why it belongs

Helps people compare how different LLMs respond to the same prompt side by side, so you can evaluate model differences yourself instead of trusting a single model's answer.

## Quality signals

- License: MIT License
- Maintenance status: Actively maintained
- Documentation/examples: README covers setup, usage, and how to configure models. Repo includes an examples/ folder with sample JSON and Markdown exports from a real comparison run.
<img width="353" height="656" alt="plenumview-comparison (1)" src="https://github.com/user-attachments/assets/3773d468-ee16-4235-9387-c067fec2ebab" />
- Distinction from similar projects: PlenumView is a comparison surface, not an automation or agent-orchestration tool. It runs one prompt against multiple models at once and shows the raw responses side by side, it doesn't chain models into a pipeline, and it doesn't score or pick a "best" answer. That judgment stays with the user.