### PR TITLE
Add ThoughtDAG to User Interfaces & Self-hosted Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1184,6 +1184,7 @@ Good entries should have a clear reason to exist. They should help people build,
 - [AIRI](https://github.com/moeru-ai/airi) - Self-hosted cyber companion and VTuber platform with Live2D character rendering, real-time voice chat, and game integration capabilities. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/moeru-ai/airi?style=social)
 - [Next AI Draw.io](https://github.com/DayuanJiang/next-ai-draw-io) - Next.js web application that integrates AI capabilities with draw.io diagrams to create and edit diagrams through natural language. Apache-2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/DayuanJiang/next-ai-draw-io?style=social)
 - [nanobot](https://github.com/HKUDS/nanobot) - Lightweight personal AI agent with a built-in WebUI, model routing, MCP, and multi-channel chat integrations. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/HKUDS/nanobot?style=social)
+- [ThoughtDAG](https://github.com/chenxiachan/thoughtdag) - Local-first visual LLM workspace where graph edges determine the context sent to the model, with branching, merging, document extraction, and Ollama or OpenAI-compatible endpoint support. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/chenxiachan/thoughtdag?style=social)
 
 #### Full Self-hosted AI Platforms
 


### PR DESCRIPTION
## Project

- Name: ThoughtDAG
- URL: https://github.com/chenxiachan/thoughtdag
- Category: User Interfaces & Self-hosted Platforms / Local AI Chat UIs & Personal Assistants

## Why it belongs

ThoughtDAG is a local-first visual LLM workspace where graph edges determine which upstream conversation and document nodes are included in the next model request. It gives users explicit control over branching, merging, and pruning context while supporting Ollama and OpenAI-compatible endpoints.

## Quality signals

- License: MIT
- Maintenance status: Actively maintained
- Documentation/examples: README, live demo, and setup documentation are available in the repository
- Distinction from similar projects: The graph is not just a visual workflow; its edges directly determine model context

Disclosure: I maintain ThoughtDAG.