### PR TITLE
Add Entroly to Prompt Engineering and Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1372,6 +1372,7 @@ Good entries should have a clear reason to exist. They should help people build,
 
 - [Helicone](https://github.com/Helicone/helicone) - Open-source LLM observability platform with prompt management, versioning, and experimentation. One-line integration, YC W23 company. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/Helicone/helicone?style=social)
 - [GEPA](https://github.com/gepa-ai/gepa) - Reflective prompt evolution optimizer using natural language reflection and Pareto frontier learning. Outperforms reinforcement learning for prompt optimization. Integrated with DSPY and MLflow. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/gepa-ai/gepa?style=social)
+- [Entroly](https://github.com/juyterman1000/entroly) - Local-first MCP server for explicit-budget context selection, content-addressed exact recovery, and auditable Context Receipts. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/juyterman1000/entroly?style=social)
 
 ---
 


### PR DESCRIPTION
Adds Entroly to Prompt Engineering & Management using the repository's existing one-line format.

- One factual sentence plus Apache 2.0 license and GitHub stars badge
- UTF-8 without BOM; existing README characters preserved
- No universal savings or benchmark claims
- `python3 tools/validate_awesome.py --skip-remote`: 0 errors, 0 warnings

Disclosure: I maintain Entroly.