### PR TITLE
Add Agent Skills (Anthropic) to Autonomous Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ Good entries should have a clear reason to exist. They should help people build,
 - [AG Kit](https://github.com/vudovn/ag-kit) - Antigravity-first agent engineering kit featuring rules, skills, persistent memory, MCP guidance, and a native safety hook. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/vudovn/ag-kit?style=social)
 - [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) - Self-improving recursive language model (RLM) agent for coding workflows and autonomous tasks. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/PrimeIntellect-ai/prime-agent?style=social)
 - [Agent Skills (Google)](https://github.com/google/skills) - Official collection of Agent Skills for Google Cloud and Google developer platforms, extending AI coding agents with product and technology workflows. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/google/skills?style=social)
+- [Agent Skills (Anthropic)](https://github.com/anthropics/skills) - Official collection of Agent Skills and reference implementations for Claude Code, Claude API, and AI agents. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/anthropics/skills?style=social)
 
 #### Prompt Engineering & Structured Outputs
 


### PR DESCRIPTION
## Project
- Name: Agent Skills (Anthropic)
- URL: https://github.com/anthropics/skills
- Category: Autonomous Coding Agents

## Why it belongs
Official collection of Agent Skills and reference implementations by Anthropic for Claude Code, Claude API, and AI agents.

## Quality signals
- License: Apache 2.0
- Maintenance: Active
- Distinction: Primary reference repository for Anthropic's Agent Skills format