### PR TITLE
Add Mydentify AI Crawler Access Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1365,6 +1365,7 @@ Good entries should have a clear reason to exist. They should help people build,
 
 #### Testing & Debugging Tools
 
+- [AI Crawler Access Checker](https://github.com/mitdralla/mydentify-ai-crawler-access-checker) - MIT-licensed Node CLI and browser tool for checking robots.txt rules, page directives, response headers, and documented OpenAI and Anthropic crawler user agents without claiming provider-IP verification. ![GitHub stars](https://img.shields.io/github/stars/mitdralla/mydentify-ai-crawler-access-checker?style=social)
 - [no-mistakes](https://github.com/kunchenguid/no-mistakes) - A local Git proxy and validation pipeline that runs AI-driven checks and applies fixes in a temporary worktree before forwarding pushes and opening clean PRs. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/kunchenguid/no-mistakes?style=social)
 - [oai-smoke](https://github.com/airouter-dev/openai-compatible-api-smoke-test) - MIT-licensed, standard-library-only Go CLI that validates `/models` and opt-in `/chat/completions` behavior for OpenAI-compatible APIs and emits bounded diagnostics without credentials or response bodies. ![GitHub stars](https://img.shields.io/github/stars/airouter-dev/openai-compatible-api-smoke-test?style=social)
 


### PR DESCRIPTION
## Project

- Name: AI Crawler Access Checker
- URL: https://github.com/mitdralla/mydentify-ai-crawler-access-checker
- Category: Developer Tools & Integrations → Testing & Debugging Tools

## Why it belongs

AI Crawler Access Checker helps site owners and AI builders inspect whether documented OpenAI and Anthropic crawler user agents can reach a path. It checks robots.txt rules, page directives, response headers, and clearly labeled user-agent probes through a dependency-free Node CLI and browser demo. It does not claim that probes come from provider IP ranges.

## Quality signals

- License: MIT, with a visible LICENSE file
- Maintenance status: active repository with a v1.1.4 release and recent August 2026 commits
- Documentation/examples: README, CLI usage, browser demo, tests, and limitation notes
- Distinction from similar projects: focused on crawler access and indexing signals rather than model evaluation or content generation

The maintainer relationship is disclosed: this project is maintained by the Mydentify founder. The entry is one factual line and requests no reciprocal link or engagement.
