### PR TITLE
Add MCP Lens to IDE Plugins & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1326,6 +1326,7 @@ Good entries should have a clear reason to exist. They should help people build,
 - [Code Review Graph](https://github.com/tirth8205/code-review-graph) - Local-first code intelligence graph that builds a persistent map of a codebase to provide token-optimized context for AI coding tools. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/tirth8205/code-review-graph?style=social)
 - [CAD Skills](https://github.com/earthtojake/text-to-cad) - A library of modular agent skills for generating, inspecting, slicing, and exporting CAD and robot-description geometry (STEP, STL, URDF, SDF). MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/earthtojake/text-to-cad?style=social)
 - [ADHD](https://github.com/UditAkhourii/adhd) - Tree-of-thought divergent reasoning skill for AI agents that spawns parallel cognitive frames to prune traps and score surviving paths. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/UditAkhourii/adhd?style=social)
+- [MCP Lens](https://github.com/labmimors/dsh-mcp-lens) - DeepSeek Harness plugin that exposes configured remote MCP tools through a search interface and an explicit server/tool call interface with exact input schemas. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/labmimors/dsh-mcp-lens?style=social)
 
 #### UI Components & Chat Libraries
 


### PR DESCRIPTION
## Project

- Name: MCP Lens
- URL: https://github.com/labmimors/dsh-mcp-lens
- Category: Developer Tools & Integrations → IDE Plugins & Extensions

## Why it belongs

I maintain MCP Lens. It is a DeepSeek Harness plugin for discovering configured remote MCP tools and calling an explicit server/tool pair with the selected tool's input schema.

## Quality signals

- License: MIT
- Maintenance status: Active; v0.1.0-rc.9 was published on August 15, 2026, and the current main verification workflow passes.
- Documentation/examples: The repository includes installation and configuration instructions, policy examples, automated tests, and reproducible verification commands.
- Distinction from similar projects: It focuses on progressive MCP tool discovery and invocation inside DeepSeek Harness rather than operating as a general MCP registry.

## Validation

- Confirmed there is no existing MCP Lens or `labmimors/dsh-mcp-lens` entry.
- Changed only `README.md` with one new entry.
- `python3 tools/validate_awesome.py --skip-remote`: 0 errors (10 pre-existing duplicate warnings).
- `python3 -m unittest discover -s tools -p 'test_*.py'`: 4 tests passed.
- `git diff --check`: passed.

## Disclosure

I am the maintainer of MCP Lens. This submission is limited to the factual directory entry above.
