### PR TITLE
Add SandBase CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1359,6 +1359,7 @@ Good entries should have a clear reason to exist. They should help people build,
 - [Claude Code Action](https://github.com/anthropics/claude-code-action) - GitHub Action for running Claude Code in PR and issue workflows with approval-aware automation and coding assistance. ![GitHub stars](https://img.shields.io/github/stars/anthropics/claude-code-action?style=social)
 - [OfficeCLI](https://github.com/iOfficeAI/OfficeCLI) - Office suite purpose-built for AI agents to read, edit, and automate Word, Excel, and PowerPoint files without external Office installations. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/iOfficeAI/OfficeCLI?style=social)
 - [CLI-Anything](https://github.com/HKUDS/CLI-Anything) - Framework for converting software applications into agent-native command-line interfaces for AI coding agents. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/HKUDS/CLI-Anything?style=social)
+- [SandBase CLI](https://github.com/sandbaseai/cli) - Apache-2.0 CLI and local MCP bridge that configures 25 AI clients to discover, inspect, and call more than 2,000 AI models and APIs through one account. ![GitHub stars](https://img.shields.io/github/stars/sandbaseai/cli?style=social)
 
 #### SDKs & API Development Tools
 


### PR DESCRIPTION
## Project

- Name: SandBase CLI
- URL: https://github.com/sandbaseai/cli
- Category: Developer Tools & Integrations → CLI Tools & API Clients

## Why it belongs

SandBase CLI gives AI builders one open-source, local MCP bridge for configuring 25 supported AI clients and discovering, inspecting, and calling more than 2,000 model and API endpoints. It is useful when developers need the same model/API tool surface across Claude Code, Cursor, Codex, VS Code, Windsurf, and other supported clients without maintaining separate client configurations.

## Quality signals

- License: Apache-2.0
- Maintenance status: Active; latest tagged release is v0.1.17
- Documentation/examples: Repository README, SECURITY.md, client catalog, and a guided `sandbase connect` flow
- Distinction from similar projects: It focuses on installing one local MCP bridge across 25 client targets, with separate discovery, schema inspection, execution, run retrieval, and account tools for a 2,000+ endpoint catalog.

## Validation

- `python3 tools/validate_awesome.py --skip-remote` — 0 errors
- `git diff --check`

The validator reported 10 pre-existing duplicate warnings unrelated to this one-line addition.