### PR TITLE
Add Vibe-Coding Prompt Template to Prompt Engineering & Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1384,6 +1384,7 @@ Good entries should have a clear reason to exist. They should help people build,
 - [Helicone](https://github.com/Helicone/helicone) - Open-source LLM observability platform with prompt management, versioning, and experimentation. One-line integration, YC W23 company. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/Helicone/helicone?style=social)
 - [GEPA](https://github.com/gepa-ai/gepa) - Reflective prompt evolution optimizer using natural language reflection and Pareto frontier learning. Outperforms reinforcement learning for prompt optimization. Integrated with DSPY and MLflow. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/gepa-ai/gepa?style=social)
 - [Entroly](https://github.com/juyterman1000/entroly) - Local-first MCP server for explicit-budget context selection, content-addressed exact recovery, and auditable Context Receipts. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/juyterman1000/entroly?style=social)
+- [Vibe-Coding Prompt Template](https://github.com/KhazP/vibe-coding-prompt-template) - Staged prompt workflow and CLI that turns a product idea into a PRD, technical design, and `AGENTS.md` instruction files for AI coding agents. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/KhazP/vibe-coding-prompt-template?style=social)
 
 ---
 


### PR DESCRIPTION
Adds one entry to **13. Developer Tools & Integrations → Prompt Engineering & Management**.

`python3 tools/validate_awesome.py --skip-remote` → **0 errors** (the 10 warnings are pre-existing duplicate-repo notices unrelated to this change).

## Project

- Name: Vibe-Coding Prompt Template
- URL: https://github.com/KhazP/vibe-coding-prompt-template
- Category: 13. Developer Tools & Integrations → Prompt Engineering & Management

## Why it belongs

It helps people **build**: a staged prompt workflow that takes a product idea through deep research, a PRD, and a technical design, then compiles the answers into `AGENTS.md` and `agent_docs/` — the instruction files Claude Code, Cursor, Codex, and Gemini CLI actually read. The prompts are the artifact, and each stage forces the model to ask clarifying questions before producing a document, which is the part that makes downstream agent runs reproducible.

Distinct from the neighbouring entries: Helicone is observability with prompt versioning, GEPA optimizes prompts automatically, Entroly manages context budget. This one is authored, staged prompts plus the config-file generator at the end of the chain.

## Quality signals

- **License:** MIT (`LICENSE` at repo root, SPDX MIT).
- **Maintenance status:** active — commits within the last day, CLI published on npm as `vibeworkflow` (v0.2.2), CI on PRs.
- **Documentation/examples:** full README walkthrough of all five steps, `examples/` directory, `docs/`, each prompt as its own markdown file, and a `CITATION.cff`.
- **Distinction from similar projects:** not a wrapper around a model API and not a runtime — it is the planning-document layer, usable from any chat tool with no install, with an optional CLI that automates steps 1–4.

GitHub stars (context only): 2.8k, 360+ forks.
