### PR TITLE
Add deepseek-peak-hours (Testing & Debugging Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1387,6 +1387,7 @@ Good entries should have a clear reason to exist. They should help people build,
 
 #### Testing & Debugging Tools
 
+- [deepseek-peak-hours](https://github.com/xyzs996/deepseek-peak-hours) - Dated boundary vectors and a ~30-line reference implementation in Python and JavaScript for DeepSeek's peak/off-peak billing windows, with a conformance harness that runs the vectors against the peak predicate of nine published billing plugins. CC0 licensed. ![GitHub stars](https://img.shields.io/github/stars/xyzs996/deepseek-peak-hours?style=social)
 - [no-mistakes](https://github.com/kunchenguid/no-mistakes) - A local Git proxy and validation pipeline that runs AI-driven checks and applies fixes in a temporary worktree before forwarding pushes and opening clean PRs. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/kunchenguid/no-mistakes?style=social)
 - [oai-smoke](https://github.com/airouter-dev/openai-compatible-api-smoke-test) - MIT-licensed, standard-library-only Go CLI that validates `/models` and opt-in `/chat/completions` behavior for OpenAI-compatible APIs and emits bounded diagnostics without credentials or response bodies. ![GitHub stars](https://img.shields.io/github/stars/airouter-dev/openai-compatible-api-smoke-test?style=social)
 


### PR DESCRIPTION
## Project

- Name: deepseek-peak-hours
- URL: https://github.com/xyzs996/deepseek-peak-hours
- Category: 13. Developer Tools & Integrations → Testing & Debugging Tools

## Why it belongs

DeepSeek bills at half price off-peak, and the peak window is defined on the **Beijing weekday**, not the UTC one. Every implementation I have looked at gets the hour arithmetic right and then reads the weekday off the raw UTC instant — which is invisible in testing, because the Beijing weekend runs 16:00 UTC Friday → 16:00 UTC Sunday and both official peak windows sit clear of that seam. A `getUTCDay()` implementation therefore returns *identical prices for all 168 hours of a week*, and no test written against the published windows can tell the two apart.

This repo is the fixture that can: 18 dated boundary vectors plus 2 schedule-axis checks, a ~30-line reference implementation in Python and JavaScript, and a conformance harness that runs the vectors against the actual peak predicate of nine published DeepSeek billing plugins.

```
$ python3 check_vectors.py     # 20/20 passed
$ node check_vectors.mjs       # 20/20 passed, same program, no dependencies
$ node conformance/run.mjs     # 2 of 9 projects pass every vector they can run
```

It is useful to anyone who **runs** a DeepSeek cost estimate or **evaluates** an existing one — the same slot `oai-smoke` occupies for OpenAI-compatible endpoints, one layer up at the billing schedule.

Four projects have taken fixes found by running these vectors ([CodeWhale#5545](https://github.com/Hmbown/CodeWhale/pull/5545), [TokenTracker#505](https://github.com/xiufengsun/TokenTracker/pull/505), [OpenCowork#160](https://github.com/AIDotNet/OpenCowork/pull/160), [waveloom#6](https://github.com/Menfre01/waveloom/issues/6), shipped in v0.7.7 with a regression test pinning both weekend windows).

## Quality signals

- **License:** CC0 1.0 — the vectors are meant to be vendored, not depended on.
- **Maintenance status:** current. DeepSeek changed the weekend rule on 2026-08-23 (whole weekend now off-peak); the vectors and both reference implementations were updated the same day, and the README states the rule and its effective date.
- **Documentation/examples:** README leads with the three runnable commands above; `conformance/README.md` documents the adapter shape and what "not run" means for a project whose window is hard-coded and therefore cannot be pointed at another schedule. READMEs in 10 languages.
- **Distinction from similar projects:** the existing entries in this subsection validate an *API surface* (`oai-smoke`) or a *push pipeline* (`no-mistakes`). This one validates a *billing schedule* — a calendar predicate rather than a protocol. I could not find another published set of dated peak/off-peak boundary vectors for any provider; the alternative today is re-deriving the timezone arithmetic per project, which is what the 7-of-9 result measures.

## Validator

```
$ python3 tools/validate_awesome.py --skip-remote
Summary: 0 error(s), 10 warning(s)
```

All 10 warnings are pre-existing duplicate-repo notices (libretranslate, deepep, deepgemm, thunderkittens, tt-metal, agent-governance-toolkit, codegraph, headroom, supermemory, helicone) and are untouched by this change. The diff is one line.
