### PR TITLE
Add munder-difflin to Multi-Agent Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ Good entries should have a clear reason to exist. They should help people build,
 - [MiroFish](https://github.com/666ghj/MiroFish) - Multi-agent swarm intelligence engine that constructs parallel digital environments with autonomous agents to simulate and predict real-world outcomes. AGPL-3.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/666ghj/MiroFish?style=social)
 - [Maka](https://github.com/apache/maka) - Apache-incubating local-first AI-agent workspace with durable append-only agent execution history, licensed under Apache-2.0. ![GitHub stars](https://img.shields.io/github/stars/apache/maka?style=social)
 - [Ruflo](https://github.com/ruvnet/ruflo) - Multi-agent orchestration and meta-harness for coordinating agent swarms with shared memory, licensed under the MIT license. ![GitHub stars](https://img.shields.io/github/stars/ruvnet/ruflo?style=social)
+- [munder-difflin](https://github.com/chaitanyagiri/munder-difflin) - MIT-licensed desktop multi-agent workspace and harness for coordinating local coding agents across multiple LLM backends. ![GitHub stars](https://img.shields.io/github/stars/chaitanyagiri/munder-difflin?style=social)
 
 #### Agent Protocols & Standards
 


### PR DESCRIPTION
## Project

- Name: munder-difflin
- URL: https://github.com/chaitanyagiri/munder-difflin
- Category: Multi-Agent Orchestration

## Why it belongs

Desktop multi-agent workspace and harness for coordinating local coding agents across multiple LLM backends.

## Quality signals

- License: MIT
- Maintenance status: Current upstream repository
- Documentation/examples: Upstream repository documentation
- Distinction from similar projects: Desktop workspace for local coding-agent coordination