### PR TITLE
docs: add SandBase CLI to agent protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ Good entries should have a clear reason to exist. They should help people build,
 - [DESIGN.md (Google)](https://github.com/google-labs-code/design.md) - A format specification for describing visual identity to coding agents, combining YAML tokens and markdown prose to give agents a structured understanding of design systems. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/google-labs-code/design.md?style=social)
 - [Agent Skills](https://github.com/agentskills/agentskills) - Standardized specification and document format for bundling and progressively loading AI agent capabilities, instructions, scripts, and resources. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/agentskills/agentskills?style=social)
 - [FastMCP](https://github.com/PrefectHQ/fastmcp) - A Python framework for building Model Context Protocol (MCP) servers and clients with automatic schema generation and validation. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/PrefectHQ/fastmcp?style=social)
+- [SandBase CLI](https://github.com/sandbaseai/cli) - Agent-first CLI and MCP bridge connecting 25 AI clients to 2,000+ models and APIs. Apache-2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/sandbaseai/cli?style=social)
 
 #### Agent Context, Memory & Knowledge
 


### PR DESCRIPTION
## Description

Adds SandBase CLI to Agent Protocols & Standards as an open-source CLI/MCP bridge for connecting AI clients to 2,000+ models and APIs.

## Checklist

- [x] Open-source project with Apache-2.0 license
- [x] Meaningfully related to open-source AI
- [x] Description is factual and links to the canonical repository
- [x] Entry uses the repository format and star badge
- [x] `python3 tools/validate_awesome.py --skip-remote` passes (existing duplicate warnings only)

No code or dependency changes.