### PR TITLE
Add AI Novel Writer to Creative Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1099,6 +1099,7 @@ Good entries should have a clear reason to exist. They should help people build,
 #### Creative Writing & Narrative AI
 
 - [Alex](https://github.com/Alex663028/Alex-Novel-Platform) - Open-source desktop novel-writing engine and AI story scaffold with Tauri, FastAPI, SQLite, and plot-generation workflows. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/Alex663028/Alex-Novel-Platform?style=social)
+- [AI Novel Writer](https://github.com/EthanYoQ/AI-Novel-Writer) - Local-first desktop workbench for long-form fiction that organizes story premises, characters, worldbuilding, chapter blueprints, drafting, review, and revision, with Ollama support and Windows/macOS releases. GPL-3.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/EthanYoQ/AI-Novel-Writer?style=social)
 
 #### HR & Recruiting AI
 


### PR DESCRIPTION
## Project

- Name: AI Novel Writer
- URL: https://github.com/EthanYoQ/AI-Novel-Writer
- Category: Specialized Domains → Creative Writing & Narrative AI

## Why it belongs

AI Novel Writer is an open-source desktop workbench for long-form fiction. It keeps premises, characters, worldbuilding, chapter blueprints, drafts, review, and revision in one project workflow, and can connect to Ollama or user-configured model providers.

## Quality signals

- License: GPL-3.0
- Maintenance status: Active; v0.9.0 and current Windows/macOS releases are public
- Documentation/examples: Bilingual README, current UI screenshots, install packages, and release notes
- Distinction from similar projects: Focuses on a reviewable long-form writing workflow and persistent project structure rather than a single chat or prompt surface