### PR TITLE
Add Unlimited Context to Agent Memory & State

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,7 @@ Good entries should have a clear reason to exist. They should help people build,
 - [TencentDB Agent Memory](https://github.com/TencentCloud/TencentDB-Agent-Memory) - Fully local long-term memory layer for AI agents with a four-tier progressive pipeline and zero external dependencies. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/TencentCloud/TencentDB-Agent-Memory?style=social)
 - [Cognee](https://github.com/topoteretes/cognee) - AI memory platform for agents that builds a self-hosted knowledge graph for persistent, long-term memory across sessions. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/topoteretes/cognee?style=social)
 - [LoopX](https://github.com/huangruiteng/loopx) - Lightweight state kernel and local control plane for long-running AI agent loops with goal tracking, auto-wake, and verifiable handoffs. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/huangruiteng/loopx?style=social)
+- [Unlimited Context](https://github.com/AetherAI3/Unlimited-Context-LLM) - Local-first context and memory engine that keeps a billion-token encoded pool on disk and pages relevant slices into a small resident window for Ollama and other local LLMs. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/AetherAI3/Unlimited-Context-LLM?style=social)
 
 ---
 


### PR DESCRIPTION
## Project

- Name: Unlimited Context
- URL: https://github.com/AetherAI3/Unlimited-Context-LLM
- Category: 4. Agentic AI & Multi-Agent Systems -> Agent Memory & State

## Why it belongs

Unlimited Context gives a local model a large on-disk memory pool and pages the relevant slices into the resident window while it runs. It is built for long agent sessions on Ollama or another local backend, where the thing that breaks first is usually earlier detail going missing, not compute.

It does not enlarge the model's native context window. It manages what occupies that window, so the entry is worded to say exactly that.

## Quality signals

- License: Apache-2.0
- Maintenance status: active. v0.3.0 released 4 Sep 2026, published to PyPI as `aether-context` and to npm.
- Documentation/examples: README quickstart (two commands), `examples/`, `docs/`, reproducible benchmarks under `bench/`, plus CHANGELOG, CONTRIBUTING, SECURITY and a use policy.
- Distinction from similar projects: most neighbours in this subsection store extracted facts or graph nodes. This one keeps encoded context on disk (256-dim retrieval embeddings over flat / HNSW / tiered indexes) and swaps slices in and out of the live window, which is closer to virtual memory than to a fact store.

## Affiliation

I am the author and maintainer of this project.