### PR TITLE
Add Busabase to Agent Context, Memory & Knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ Good entries should have a clear reason to exist. They should help people build,
 - [codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp) - High-performance C-based codebase intelligence engine and MCP server that indexes repositories into local type-resolved knowledge graphs. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/DeusData/codebase-memory-mcp?style=social)
 - [book-to-skill](https://github.com/virgiliojr94/book-to-skill) - CLI tool that distills technical books, documents, and reference materials into structured, on-demand agent skills. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/virgiliojr94/book-to-skill?style=social)
 - [AI Memory](https://github.com/akitaonrails/ai-memory) - Rust-native long-term memory server and MCP client for agent coding CLIs, featuring Karpathy-style LLM wiki compilation, FTS5 recall, and cross-agent session handoffs. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/akitaonrails/ai-memory?style=social)
+- [Busabase](https://github.com/busabase/busabase) - Open-source database and workspace that gives AI agents structured data, durable knowledge, docs, skills, and apps through MCP, OpenAPI, CLI, and coding-agent skills; material writes can remain reviewable ChangeRequests before becoming canonical. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/busabase/busabase?style=social)
 
 #### Autonomous Coding Agents
 


### PR DESCRIPTION
## Project

- Name: Busabase
- URL: https://github.com/busabase/busabase
- Category: Agent Context, Memory & Knowledge

## Why it belongs

Busabase gives AI agents one workspace for typed operational data, durable knowledge, docs, skills, and runnable apps through MCP, OpenAPI, CLI, and coding-agent skills. Its distinction from memory-only stores is the governed system-of-record boundary: permission-scoped agents can propose material writes as ChangeRequests without forcing them into canonical workspace state.

## Quality signals

- License: MIT
- Maintenance status: active; v0.52.1 released 2026-09-09, with nine public releases and current npm/Docker/Desktop distributions
- Documentation/examples: README includes Quick Start, workspace model, screenshots, MCP/OpenAPI/CLI setup, and self-hosting instructions
- Distinction from similar projects: combines structured operational data and durable knowledge with reviewable, attributable changes rather than only extracting or retrieving memory

## Validation

- `python3 tools/validate_awesome.py --skip-remote`: 0 errors; 10 pre-existing duplicate warnings
- Optional GitHub-backed validation: Busabase passes; one unrelated stale-repository error and four archived-repository warnings are pre-existing on `main`
- One `README.md` entry, +1/-0; `git diff --check` passed
- Repository, license, star badge, npm package, Docker image, and OpenAPI URLs verified live

Disclosure: I work on Busabase. This PR was prepared with AI assistance and reviewed before submission.