### PR TITLE
Add Mnemoverse to Agent Memory & State

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,7 @@ Good entries should have a clear reason to exist. They should help people build,
 - [LoopX](https://github.com/huangruiteng/loopx) - Lightweight state kernel and local control plane for long-running AI agent loops with goal tracking, auto-wake, and verifiable handoffs. MIT licensed. ![GitHub stars](https://img.shields.io/github/stars/huangruiteng/loopx?style=social)
 - [Unlimited Context](https://github.com/AetherAI3/Unlimited-Context-LLM) - Local-first context and memory engine that keeps a billion-token encoded pool on disk and pages relevant slices into a small resident window for Ollama and other local LLMs. Apache 2.0 licensed. ![GitHub stars](https://img.shields.io/github/stars/AetherAI3/Unlimited-Context-LLM?style=social)
 - [inspeximus](https://github.com/DanceNitra/inspeximus) - Memory layer that retires a corrected fact by key and can undo the correction later from the key alone. Zero-dependency core with an MCP server. ![GitHub stars](https://img.shields.io/github/stars/DanceNitra/inspeximus?style=social)
+- [Mnemoverse](https://github.com/mnemoverse/mcp-memory-server) - MIT-licensed MCP server for agent memory, backed by a hosted engine that re-ranks recall from reported outcomes rather than similarity alone, with one key shared across Claude Code, Cursor, VS Code, and ChatGPT. ![GitHub stars](https://img.shields.io/github/stars/mnemoverse/mcp-memory-server?style=social)
 
 ---
 


### PR DESCRIPTION
## Project

- Name: Mnemoverse
- URL: https://github.com/mnemoverse/mcp-memory-server
- Category: 4. AI Agents & Automation -> Agent Memory & State

## Why it belongs

It gives a coding agent memory that survives the session and follows the developer between tools. The repository is the MCP server: write a decision in Claude Code, recall it in Cursor or VS Code through the same account.

The mechanism it adds to this section is outcome feedback. Most entries here score recall by embedding similarity. This one takes a report on whether a retrieved memory actually helped and applies a Rescorla-Wagner update on the prediction error, so a memory that misled sinks and a memory that helped rises. Unused memories decay by recency.

Disclosure so the license question is settled up front rather than found later: I am affiliated with the project, the server in this repository is MIT, and the memory engine it talks to is a hosted service that needs a free API key. Supermemory and Hindsight in this same subsection follow the same split. If that split puts it outside what this list means by open source, I would rather you say so on the PR than merge it and regret it.

## Quality signals

- License: MIT, declared in package.json and in LICENSE at the repository root
- Maintenance status: published on npm as @mnemoverse/mcp-memory-server, latest release 0.9.1 on 2026-08-24, and listed in the official MCP Registry as io.github.mnemoverse/mcp-memory-server
- Documentation/examples: README carries working install commands for Claude Code, Cursor, VS Code, Codex and ChatGPT, an environment variable table, and a section on what the server sends and what it does not
- Distinction from similar projects: feedback re-ranking and recency decay instead of similarity scoring alone; shared rooms let two accounts read the same memories under an invite scope

Validator run locally before opening: `python3 tools/validate_awesome.py --skip-remote` reports 0 errors. The 10 warnings it prints are pre-existing duplicate-repo notices in unrelated sections.
